### PR TITLE
feat: add training func for torch models

### DIFF
--- a/notebooks/train_cifar10.py
+++ b/notebooks/train_cifar10.py
@@ -77,9 +77,10 @@ if __name__ == "__main__":
         training_func = train_keras_app
     elif args.framework == "torch":
         # important: this needs to be imported before loading dataset
-        from oodeel.models.training_funs import train_torch_model
+        from oodeel.models.training_funs import train_torch_model, run_tf_on_cpu
 
         training_func = train_torch_model
+        run_tf_on_cpu()
 
     # cifar10
     data_handler = DataHandler()

--- a/oodeel/models/training_funs/__init__.py
+++ b/oodeel/models/training_funs/__init__.py
@@ -21,5 +21,6 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 from .keras_models import train_keras_app
+from .torch_models import run_tf_on_cpu
 from .torch_models import train_torch_model
 from .toy import train_convnet

--- a/oodeel/models/training_funs/torch_models.py
+++ b/oodeel/models/training_funs/torch_models.py
@@ -34,21 +34,14 @@ from tqdm import tqdm
 from ...utils import dataset_image_shape
 
 
-def allow_growth():
-    """Prevent tensorflow from allocating the totality of the GPU so that
+def run_tf_on_cpu():
+    """Run tensorflow on cpu device.
+    It prevents tensorflow from allocating the totality of the GPU so that
     some VRAM remain free to train torch models.
 
     /!\\ This function needs to be called BEFORE loading the tfds dataset!
     """
-    physical_devices = tf.config.list_physical_devices("GPU")
-    try:
-        tf.config.experimental.set_memory_growth(physical_devices[0], True)
-    except:
-        # Invalid device or cannot modify virtual devices once initialized.
-        pass
-
-
-allow_growth()
+    tf.config.set_visible_devices([], "GPU")
 
 
 def train_torch_model(


### PR DESCRIPTION
**Features:** 
- Add standard training loop for torch models, while iterating over tdfs datasets. The API is the same as that of `train_keras_app` function. 
- Refactor `train_cifar10` with the add of a parser to easily train using either keras or torch model.

**Note**: A function `allow_growth` is called at the import of the `oodeel.models.training_funcs.torch_models` module. It prevents tensorflow from allocating the totality of the GPU when a tfds dataset is loaded, so that some VRAM remain free to train torch models. Thus, the `torch_models` module absolutely needs to be loaded **BEFORE** calling `data_handler.load_tfds`.

**Run training on CIFAR-10:**
```bash
 python -m notebooks.train_cifar10 --framework 'torch' --save_dir 'saved_models/cifar10-torch'
```