### PR TITLE
Fixed docstrings with docsig tool

### DIFF
--- a/oodeel/datasets/ooddataset.py
+++ b/oodeel/datasets/ooddataset.py
@@ -110,7 +110,7 @@ class OODDataset(object):
         else:
             self.input_key = input_key
 
-    def __len__(self):
+    def __len__(self) -> int:
         """get the length of the dataset.
 
         Returns:
@@ -122,7 +122,11 @@ class OODDataset(object):
 
     @property
     def has_ood_label(self) -> bool:
-        """Check if the dataset has an out-of-distribution label."""
+        """Check if the dataset has an out-of-distribution label.
+
+        Returns:
+            bool: True if data handler has a "ood_label" feature key.
+        """
         return self._data_handler.has_feature_key(self.data, "ood_label")
 
     def get_ood_labels(

--- a/oodeel/datasets/torch_data_handler.py
+++ b/oodeel/datasets/torch_data_handler.py
@@ -265,6 +265,7 @@ class TorchDataHandler(DataHandler):
     torch syntax.
     """
 
+    @staticmethod
     def _default_target_transform(y: Any) -> torch.Tensor:
         """Format int or float item target as a torch tensor
 
@@ -277,7 +278,7 @@ class TorchDataHandler(DataHandler):
         return torch.tensor(y) if isinstance(y, (float, int)) else y
 
     DEFAULT_TRANSFORM = torchvision.transforms.PILToTensor()
-    DEFAULT_TARGET_TRANSFORM = _default_target_transform
+    DEFAULT_TARGET_TRANSFORM = _default_target_transform.__func__
 
     @classmethod
     def load_dataset(

--- a/oodeel/datasets/torch_data_handler.py
+++ b/oodeel/datasets/torch_data_handler.py
@@ -142,7 +142,7 @@ class DictDataset(Dataset):
         dummy_item = self[0]
         return [dummy_item[key].shape for key in self.output_keys]
 
-    def _check_init_args(self):
+    def _check_init_args(self) -> None:
         """Check validity of dataset and output keys provided at init"""
         dummy_item = self._dataset[0]
         assert isinstance(

--- a/oodeel/datasets/torch_data_handler.py
+++ b/oodeel/datasets/torch_data_handler.py
@@ -124,13 +124,21 @@ class DictDataset(Dataset):
 
     @property
     def output_keys(self) -> list:
-        """Get the list of keys in a dict-based item from the dataset"""
+        """Get the list of keys in a dict-based item from the dataset.
+
+        Returns:
+            list: feature keys of the dataset.
+        """
         dummy_item = self[0]
         return list(dummy_item.keys())
 
     @property
     def output_shapes(self) -> list:
-        """Get a list of the tensor shapes in an item from the dataset"""
+        """Get a list of the tensor shapes in an item from the dataset.
+
+        Returns:
+            list: tensor shapes of an dataset item.
+        """
         dummy_item = self[0]
         return [dummy_item[key].shape for key in self.output_keys]
 
@@ -146,8 +154,15 @@ class DictDataset(Dataset):
             self._raw_output_keys
         ), "Length mismatch between dataset item and provided keys"
 
-    def __getitem__(self, index: int):
-        """Return a dictionary of tensors corresponding to a specfic index"""
+    def __getitem__(self, index: int) -> dict:
+        """Return a dictionary of tensors corresponding to a specfic index.
+
+        Args:
+            index (int): the index of the item to retrieve.
+
+        Returns:
+            dict: tensors for the item at the specific index.
+        """
         item = self._dataset[index]
 
         # convert item to a list / tuple of tensors
@@ -234,7 +249,12 @@ class DictDataset(Dataset):
             )
         return dataset
 
-    def __len__(self):
+    def __len__(self) -> int:
+        """Return the length of the dataset, i.e. the number of items.
+
+        Returns:
+            int: length of the dataset.
+        """
         return len(self._dataset)
 
 

--- a/oodeel/methods/base.py
+++ b/oodeel/methods/base.py
@@ -60,10 +60,14 @@ class OODModel(ABC):
     @abstractmethod
     def _score_tensor(self, inputs: TensorType) -> np.ndarray:
         """Computes an OOD score for input samples "inputs".
+
         Method to override with child classes.
 
         Args:
-            inputs: tensor to score
+            inputs (TensorType): tensor to score
+
+        Returns:
+            np.ndarray: OOD scores
 
         Raises:
             NotImplementedError: _description_
@@ -97,8 +101,10 @@ class OODModel(ABC):
         Loads feature extractor
 
         Args:
-            model : tf.keras model (for now)
-                keras models saved as pb files e.g. with model.save()
+            model: a model (Keras or PyTorch) to load.
+
+        Returns:
+            FeatureExtractor: a feature extractor instance
         """
         if is_from(model, "keras"):
             from ..models.keras_feature_extractor import KerasFeatureExtractor
@@ -130,9 +136,10 @@ class OODModel(ABC):
         )
         return feature_extractor
 
-    def _fit_to_dataset(self, fit_dataset: Union[TensorType, DatasetType]):
+    def _fit_to_dataset(self, fit_dataset: Union[TensorType, DatasetType]) -> None:
         """
         Fits the oodmodel to fit_dataset.
+
         To be overrided in child classes (if needed)
 
         Args:

--- a/oodeel/methods/base.py
+++ b/oodeel/methods/base.py
@@ -194,7 +194,7 @@ class OODModel(ABC):
         Returns whether the input samples "inputs" are OOD or not, given a threshold
 
         Args:
-            dataset (dataset: Union[TensorType, DatasetType]): dataset or tensors to score
+            dataset (Union[TensorType, DatasetType]): dataset or tensors to score
             threshold (float): threshold to use for distinguishing between OOD and ID
 
         Returns:
@@ -225,5 +225,12 @@ class OODModel(ABC):
     ) -> np.ndarray:
         """
         Convenience wrapper for isood
+
+        Args:
+            inputs (Union[TensorType, DatasetType]): dataset or tensors to score.
+            threshold (float): threshold to use for distinguishing between OOD and ID
+
+        Returns:
+            np.ndarray: array of 0 for ID samples and 1 for OOD samples
         """
         return self.isood(inputs, threshold)

--- a/oodeel/methods/dknn.py
+++ b/oodeel/methods/dknn.py
@@ -54,7 +54,7 @@ class DKNN(OODModel):
         self.index = None
         self.nearest = nearest
 
-    def _fit_to_dataset(self, fit_dataset: Union[TensorType, DatasetType]):
+    def _fit_to_dataset(self, fit_dataset: Union[TensorType, DatasetType]) -> None:
         """
         Constructs the index from ID data "fit_dataset", which will be used for
         nearest neighbor search.
@@ -89,4 +89,12 @@ class DKNN(OODModel):
         return scores[:, -1]
 
     def _l2_normalization(self, feat: np.ndarray) -> np.ndarray:
+        """L2 normalization of a tensor along the last dimension.
+
+        Args:
+            feat (np.ndarray): the tensor to normalize
+
+        Returns:
+            np.ndarray: the normalized tensor
+        """
         return feat / (np.linalg.norm(feat, ord=2, axis=-1, keepdims=True) + 1e-10)

--- a/oodeel/methods/energy.py
+++ b/oodeel/methods/energy.py
@@ -45,12 +45,6 @@ class Energy(OODModel):
     where $model(x)=(l_{c})_{c=1}^{C}$ are the logits predicted by the model on
     $x$.
     As always, training data is expected to have lower score than OOD data.
-
-
-    Args:
-        batch_size: batch_size used to compute the features space
-            projection of input data.
-            Defaults to 256.
     """
 
     def __init__(self):

--- a/oodeel/methods/mahalanobis.py
+++ b/oodeel/methods/mahalanobis.py
@@ -49,7 +49,7 @@ class Mahalanobis(OODModel):
         super(Mahalanobis, self).__init__(output_layers_id=output_layers_id)
         self.eps = eps
 
-    def _fit_to_dataset(self, fit_dataset: DatasetType):
+    def _fit_to_dataset(self, fit_dataset: DatasetType) -> None:
         """
         Constructs the mean covariance matrix from ID data "fit_dataset", whose
         pseudo-inverse will be used for mahalanobis distance computation.

--- a/oodeel/methods/mls.py
+++ b/oodeel/methods/mls.py
@@ -36,15 +36,10 @@ class MLS(OODModel):
     in Neural Networks"
     http://arxiv.org/abs/1610.02136
 
-
-
     Args:
         output_activation: activation function for the last layer. If "linear",
             the method is MLS and if "softmax", the method is MSS.
             Defaults to "linear".
-        batch_size: batch_size used to compute the features space
-            projection of input data.
-            Defaults to 256.
     """
 
     def __init__(self, output_activation="linear"):

--- a/oodeel/methods/odin.py
+++ b/oodeel/methods/odin.py
@@ -82,7 +82,16 @@ class ODIN(OODModel):
         inputs_p = inputs - self.noise * self.op.sign(gradients)
         return inputs_p
 
-    def _temperature_loss(self, inputs, labels):
+    def _temperature_loss(self, inputs: TensorType, labels: TensorType) -> TensorType:
+        """Compute the tempered cross-entropy loss.
+
+        Args:
+            inputs (TensorType): the inputs of the model.
+            labels (TensorType): the labels to fit on.
+
+        Returns:
+            TensorType: the cross-entropy loss.
+        """
         preds = self.feature_extractor.model(inputs) / self.temperature
         loss = self.op.CrossEntropyLoss(reduction="sum")(inputs=preds, targets=labels)
         return loss

--- a/oodeel/methods/vim.py
+++ b/oodeel/methods/vim.py
@@ -99,7 +99,7 @@ class VIM(OODModel):
         self._princ_dim = princ_dims
         self.pca_origin = pca_origin
 
-    def _fit_to_dataset(self, fit_dataset: Union[TensorType, DatasetType]):
+    def _fit_to_dataset(self, fit_dataset: Union[TensorType, DatasetType]) -> None:
         """
         Computes principal components of feature representations and store the residual
         eigenvectors.

--- a/oodeel/models/feature_extractor.py
+++ b/oodeel/models/feature_extractor.py
@@ -42,17 +42,10 @@ class FeatureExtractor(ABC):
             If int, the rank of the layer in the layer list
             If str, the name of the layer.
             Defaults to [].
-        output_activation: activation function for the last layer.
-            Defaults to None.
         input_layer_id: input layer of the feature extractor (to avoid useless forwards
             when working on the feature space without finetuning the bottom of the
             model).
             Defaults to None.
-        flatten: Flatten the output features or not.
-            Defaults to False.
-        batch_size: batch_size used to compute the features space
-            projection of input data.
-            Defaults to 256.
     """
 
     def __init__(
@@ -115,6 +108,12 @@ class FeatureExtractor(ABC):
 
     def __call__(self, inputs: Any) -> Any:
         """
-        Choose to call predict or predict_tensor depending on the type of inputs
+        Convenience wrapper for predict_tensor().
+
+        Args:
+            inputs (Any): input tensor
+
+        Returns:
+            Any: features
         """
         return self.predict_tensor(inputs)

--- a/oodeel/models/training_funs_torch/torch_models.py
+++ b/oodeel/models/training_funs_torch/torch_models.py
@@ -76,8 +76,15 @@ class ToyTorchConvnet(nn.Sequential):
             OrderedDict([*features._modules.items(), *fcs._modules.items()])
         )
 
-    def _calculate_fc_input_shape(self, features):
-        """Get tensor shape after passing a features network."""
+    def _calculate_fc_input_shape(self, features: nn.Module) -> int:
+        """Get tensor shape after passing a features network.
+
+        Args:
+            features: the features network
+
+        Returns:
+            int: the output shape
+        """
         input_tensor = torch.ones(tuple([1] + list(self.input_shape)))
         x = features(input_tensor)
         output_size = x.view(x.size(0), -1).size(1)
@@ -176,7 +183,7 @@ def _train(
     lr_scheduler: torch.optim.lr_scheduler._LRScheduler = None,
     save_dir: str = None,
     validation_data: DataLoader = None,
-):
+) -> nn.Module:
     """Torch basic training loop
 
     Args:

--- a/oodeel/utils/general_utils.py
+++ b/oodeel/utils/general_utils.py
@@ -24,14 +24,14 @@ from ..types import Any
 
 
 def is_from(model_or_tensor: Any, framework: str) -> str:
-    """Check wether a model or tensor belongs to a specific framework
+    """Check whether a model or tensor belongs to a specific framework
 
     Args:
         model_or_tensor (Any): Neural network or Tensor
         framework (str):  Model or tensor framework ("torch" | "keras" | "tensorflow")
 
     Returns:
-        bool: Wether the model belongs to specified framework or not
+        bool: Whether the model belongs to specified framework or not
     """
     keywords_list = []
     class_parents = list(model_or_tensor.__class__.__mro__)


### PR DESCRIPTION
Inconsistent docstrings have been fixed using `docsig` tool.
To run docsig: `docsig -c -D -o -P -p oodeel/` 
See [docsig documentation](https://docsig.readthedocs.io/en/latest/readme.html)

Note that docstrings of all operators were left unchanged (`operator.py`, `tf_operator.py` and `torch_operator.py`). It seems that it does not bring much value to document all these atomic operators.
