### PR TITLE
docs: add github actions badges to README

### DIFF
--- a/.github/workflows/python-linters.yml
+++ b/.github/workflows/python-linters.yml
@@ -1,4 +1,4 @@
-name: oodeel linters
+name: flake8
 
 on:
   push:

--- a/.github/workflows/python-tests-tf.yml
+++ b/.github/workflows/python-tests-tf.yml
@@ -1,4 +1,4 @@
-name: oodeel tests tensorflow
+name: pytest [tensorflow]
 
 on:
   push:

--- a/.github/workflows/python-tests-torch.yml
+++ b/.github/workflows/python-tests-torch.yml
@@ -1,4 +1,4 @@
-name: oodeel tests torch
+name: pytest [torch]
 
 on:
   push:

--- a/README.md
+++ b/README.md
@@ -12,7 +12,16 @@
 <!-- Badge section -->
 <div align="center">
     <a href="#">
-        <img src="https://img.shields.io/badge/Python-3.8, 3.9, 3.10-efefef">
+        <img src="https://img.shields.io/badge/python-3.8%2B-blue">
+    </a>
+    <a href="https://github.com/deel-ai/oodeel/actions/workflows/python-linters.yml">
+        <img alt="PyLint" src="https://github.com/deel-ai/oodeel/actions/workflows/python-linters.yml/badge.svg">
+    </a>
+    <a href="https://github.com/deel-ai/oodeel/actions/workflows/python-tests-tf.yml">
+        <img alt="PyLint" src="https://github.com/deel-ai/oodeel/actions/workflows/python-tests-tf.yml/badge.svg">
+    </a>
+    <a href="https://github.com/deel-ai/oodeel/actions/workflows/python-tests-tf.yml">
+        <img alt="PyLint" src="https://github.com/deel-ai/oodeel/actions/workflows/python-tests-torch.yml/badge.svg">
     </a>
     <a href="#">
         <img src="https://img.shields.io/badge/License-MIT-efefef">
@@ -69,7 +78,7 @@ Load in-distribution and out-of-distribution datasets.
 ```python
 from oodeel.datasets import OODDataset
 
-ds_in = OODDataset('mnist', split="test", backend="tensorflow").prepare(batch_size) # use backend="torch" if you prefer torch.DataLoader 
+ds_in = OODDataset('mnist', split="test", backend="tensorflow").prepare(batch_size) # use backend="torch" if you prefer torch.DataLoader
 ds_out = OODDataset('fashion_mnist', split="test", backend="tensorflow").prepare(batch_size)
 ```
 


### PR DESCRIPTION
**New badges:**
* colored python 3.8+ badge
* github actions badges for pylint, pytest [torch] and pytest [tensorflow]

Check [here](https://github.com/deel-ai/oodeel/tree/docs/fancy_README) to see the result.