### PR TITLE
docs: fix colourless README

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ mls = MLS()
 mls.fit(model) # A tensorflow or torch model
 scores = mls.score(ds) # ds is a tf.data.Dataset or a torch.DataLoader
 ```
+
 **Disclaimer**: It is still very much a work in progress, see issues and [development roadmap](#development-roadmap). Please use the lib carefully!
 
 # Table of contents

--- a/docs/index.md
+++ b/docs/index.md
@@ -36,6 +36,7 @@ mls = MLS()
 mls.fit(model)
 scores = mls.score(ds)
 ```
+
 **Disclaimer**: It is still very much a work in progress, see issues and [development roadmap](#development-roadmap). Please use the lib carefully!
 
 # Table of contents


### PR DESCRIPTION
Adding a space after the code cells seems to resolve the problem of colourless README. 🤷‍♂️ 