### PR TITLE
fix: add tf.data.Dataset in DatasetType when 2 libs avail

### DIFF
--- a/oodeel/types/__init__.py
+++ b/oodeel/types/__init__.py
@@ -54,7 +54,7 @@ except ImportError:
 
 
 if len(avail_lib) == 2:
-    DatasetType = Type[torch.utils.data.DataLoader]
+    DatasetType = Union[tf.data.Dataset, torch.utils.data.DataLoader]
     TensorType = Union[tf.Tensor, torch.Tensor, np.ndarray]
     ItemType = Union[
         tf.Tensor,


### PR DESCRIPTION
`tf.data.Dataset` was missing in `DatasetType` when tf and torch are both available.