### PR TITLE
Add configuration for coverage + unit tests for metrics

### DIFF
--- a/oodeel/eval/metrics.py
+++ b/oodeel/eval/metrics.py
@@ -48,8 +48,10 @@ def bench_metrics(
             the OOD detector to evaluate. If a tuple is provided,
             the first array is considered in-distribution scores, and the second
             is considered out-of-distribution scores.
-        labels (Optional[np.ndarray], optional): labels denoting oodness. When labels
-            is not None, the following in_values and out_values are not used.
+        labels (Optional[np.ndarray], optional): labels denoting oodness. When scores is
+            a tuple, this argument and the following in_value and out_value are not
+            used. If scores is a np.ndarray, labels are required with in_value and
+            out_value if different from their default values.
             Defaults to None.
         in_value (Optional[int], optional): ood label value for in-distribution data.
             Defaults to 0.
@@ -74,10 +76,13 @@ def bench_metrics(
             "Provide labels with scores, or provide a tuple of in-distribution "
             "and out-of-distribution scores arrays"
         )
+        labels = np.copy(labels)  # to avoid mutable np.array to be modified
+        labels[labels == in_value] = 0
+        labels[labels == out_value] = 1
     elif isinstance(scores, tuple):
         scores_in, scores_out = scores
         scores = np.concatenate([scores_in, scores_out])
-        labels = np.concatenate([scores_in * 0 + in_value, scores_out * 0 + out_value])
+        labels = np.concatenate([scores_in * 0, scores_out * 0 + 1])
 
     fpr, tpr, fnr, tnr, acc = get_curve(scores, labels, step)
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,6 +29,11 @@ ignore_missing_imports = True
 [mypy-scipy]
 ignore_missing_imports = True
 
+[coverage:report]
+exclude_also =
+    raise NotImplementedError
+    except ImportError
+
 [tox:tox]
 envlist = py{38,39,310}-tf{24,25,27,28,211},py{38,39,310}-torch{17,19,110,113,200},py{38,39,310}-lint,py{39}-tf{211}-torch{112}-coverage
 

--- a/tests/tests_tensorflow/eval/test_tf_metrics.py
+++ b/tests/tests_tensorflow/eval/test_tf_metrics.py
@@ -66,7 +66,7 @@ def test_get_curve():
 
 @pytest.mark.parametrize("in_value,out_value", [(0.0, 1.0), (2.0, 4.0)])
 def test_bench_metrics(in_value, out_value):
-    labels = np.array([0.0] * 5 + [1.0] * 5)  # 5 ID + 5 OOD samples
+    labels = np.array([in_value] * 5 + [out_value] * 5)  # 5 ID + 5 OOD samples
     scores = np.array([0.0] + [0.2] * 6 + [1.0] * 3)  # ID: 1x0, 4x0.2 / OOD: 2x0.1, 3x1
     # get metrics
     metrics_dict = bench_metrics(

--- a/tests/tests_tensorflow/eval/test_tf_metrics.py
+++ b/tests/tests_tensorflow/eval/test_tf_metrics.py
@@ -23,7 +23,7 @@
 import numpy as np
 import pytest
 from pytest import approx
-from sklearn.metrics import accuracy_score
+from sklearn.metrics import accuracy_score, roc_auc_score
 
 from oodeel.eval.metrics import bench_metrics
 from oodeel.eval.metrics import ftpn
@@ -68,19 +68,30 @@ def test_get_curve():
 def test_bench_metrics(in_value, out_value):
     labels = np.array([in_value] * 5 + [out_value] * 5)  # 5 ID + 5 OOD samples
     scores = np.array([0.0] + [0.2] * 6 + [1.0] * 3)  # ID: 1x0, 4x0.2 / OOD: 2x0.1, 3x1
+    metrics = [
+        "auroc",
+        "tpr50fpr",
+        "fpr15tnr",
+        "tnr90fpr",
+        accuracy_score,
+        roc_auc_score,
+        "detect_acc",
+    ]
     # get metrics
     metrics_dict = bench_metrics(
         scores,
         labels,
         in_value,
         out_value,
-        metrics=["auroc", "tpr50fpr", "fpr15tnr", "tnr90fpr", accuracy_score],
+        metrics,
         threshold=0.5,
         step=1,
     )
     # expected results (hand calculated)
     assert metrics_dict["auroc"] == approx(1 - (0.4 * 0.8) / 2)
+    assert metrics_dict["roc_auc_score"] == approx(1 - (0.4 * 0.8) / 2)
     assert metrics_dict["accuracy_score"] == approx(8 / 10)
+    assert metrics_dict["detect_acc"] == approx(8 / 10)
     assert metrics_dict["tpr50fpr"] == 0.6
     assert metrics_dict["fpr15tnr"] == 0.8
     assert metrics_dict["tnr90fpr"] == 0.2
@@ -90,7 +101,7 @@ def test_bench_metrics(in_value, out_value):
     scores_out = scores[labels == out_value]
     metrics_dict_2 = bench_metrics(
         (scores_in, scores_out),
-        metrics=["auroc", "tpr50fpr", "fpr15tnr", "tnr90fpr", accuracy_score],
+        metrics=metrics,
         threshold=0.5,
         step=1,
     )

--- a/tests/tests_tensorflow/eval/test_tf_metrics.py
+++ b/tests/tests_tensorflow/eval/test_tf_metrics.py
@@ -84,3 +84,14 @@ def test_bench_metrics(in_value, out_value):
     assert metrics_dict["tpr50fpr"] == 0.6
     assert metrics_dict["fpr15tnr"] == 0.8
     assert metrics_dict["tnr90fpr"] == 0.2
+
+    # Assert scores as (scores_in, scores_out) return the same results
+    scores_in = scores[labels == in_value]
+    scores_out = scores[labels == out_value]
+    metrics_dict_2 = bench_metrics(
+        (scores_in, scores_out),
+        metrics=["auroc", "tpr50fpr", "fpr15tnr", "tnr90fpr", accuracy_score],
+        threshold=0.5,
+        step=1,
+    )
+    assert metrics_dict == metrics_dict_2

--- a/tests/tests_tensorflow/eval/test_tf_metrics.py
+++ b/tests/tests_tensorflow/eval/test_tf_metrics.py
@@ -23,6 +23,7 @@
 import numpy as np
 import pytest
 from pytest import approx
+from sklearn.linear_model import LinearRegression
 from sklearn.metrics import accuracy_score, roc_auc_score
 
 from oodeel.eval.metrics import bench_metrics
@@ -106,3 +107,12 @@ def test_bench_metrics(in_value, out_value):
         step=1,
     )
     assert metrics_dict == metrics_dict_2
+
+    # Assert bench_metrics() returns no metric when wrong sklearn metric name
+    metrics = bench_metrics(scores, labels, metrics=[LinearRegression], threshold=0.3)
+    assert len(metrics) == 0
+
+    # Assert bench_metrics() returns no metric when no threshold is given
+    metrics = bench_metrics(scores, labels, metrics=[accuracy_score], threshold=None)
+    print(metrics, "DEBUG")
+    assert len(metrics) == 0

--- a/tests/tests_torch/eval/test_torch_metrics.py
+++ b/tests/tests_torch/eval/test_torch_metrics.py
@@ -66,7 +66,7 @@ def test_get_curve():
 
 @pytest.mark.parametrize("in_value,out_value", [(0.0, 1.0), (2.0, 4.0)])
 def test_bench_metrics(in_value, out_value):
-    labels = np.array([0.0] * 5 + [1.0] * 5)  # 5 ID + 5 OOD samples
+    labels = np.array([in_value] * 5 + [out_value] * 5)  # 5 ID + 5 OOD samples
     scores = np.array([0.0] + [0.2] * 6 + [1.0] * 3)  # ID: 1x0, 4x0.2 / OOD: 2x0.1, 3x1
     # get metrics
     metrics_dict = bench_metrics(

--- a/tests/tests_torch/eval/test_torch_metrics.py
+++ b/tests/tests_torch/eval/test_torch_metrics.py
@@ -23,7 +23,7 @@
 import numpy as np
 import pytest
 from pytest import approx
-from sklearn.metrics import accuracy_score
+from sklearn.metrics import accuracy_score, roc_auc_score
 
 from oodeel.eval.metrics import bench_metrics
 from oodeel.eval.metrics import ftpn
@@ -68,19 +68,30 @@ def test_get_curve():
 def test_bench_metrics(in_value, out_value):
     labels = np.array([in_value] * 5 + [out_value] * 5)  # 5 ID + 5 OOD samples
     scores = np.array([0.0] + [0.2] * 6 + [1.0] * 3)  # ID: 1x0, 4x0.2 / OOD: 2x0.1, 3x1
+    metrics = [
+        "auroc",
+        "tpr50fpr",
+        "fpr15tnr",
+        "tnr90fpr",
+        accuracy_score,
+        roc_auc_score,
+        "detect_acc",
+    ]
     # get metrics
     metrics_dict = bench_metrics(
         scores,
         labels,
         in_value,
         out_value,
-        metrics=["auroc", "tpr50fpr", "fpr15tnr", "tnr90fpr", accuracy_score],
+        metrics,
         threshold=0.5,
         step=1,
     )
     # expected results (hand calculated)
     assert metrics_dict["auroc"] == approx(1 - (0.4 * 0.8) / 2)
+    assert metrics_dict["roc_auc_score"] == approx(1 - (0.4 * 0.8) / 2)
     assert metrics_dict["accuracy_score"] == approx(8 / 10)
+    assert metrics_dict["detect_acc"] == approx(8 / 10)
     assert metrics_dict["tpr50fpr"] == 0.6
     assert metrics_dict["fpr15tnr"] == 0.8
     assert metrics_dict["tnr90fpr"] == 0.2
@@ -90,7 +101,7 @@ def test_bench_metrics(in_value, out_value):
     scores_out = scores[labels == out_value]
     metrics_dict_2 = bench_metrics(
         (scores_in, scores_out),
-        metrics=["auroc", "tpr50fpr", "fpr15tnr", "tnr90fpr", accuracy_score],
+        metrics=metrics,
         threshold=0.5,
         step=1,
     )

--- a/tests/tests_torch/eval/test_torch_metrics.py
+++ b/tests/tests_torch/eval/test_torch_metrics.py
@@ -84,3 +84,14 @@ def test_bench_metrics(in_value, out_value):
     assert metrics_dict["tpr50fpr"] == 0.6
     assert metrics_dict["fpr15tnr"] == 0.8
     assert metrics_dict["tnr90fpr"] == 0.2
+
+    # Assert scores as (scores_in, scores_out) return the same results
+    scores_in = scores[labels == in_value]
+    scores_out = scores[labels == out_value]
+    metrics_dict_2 = bench_metrics(
+        (scores_in, scores_out),
+        metrics=["auroc", "tpr50fpr", "fpr15tnr", "tnr90fpr", accuracy_score],
+        threshold=0.5,
+        step=1,
+    )
+    assert metrics_dict == metrics_dict_2

--- a/tests/tests_torch/eval/test_torch_metrics.py
+++ b/tests/tests_torch/eval/test_torch_metrics.py
@@ -23,6 +23,7 @@
 import numpy as np
 import pytest
 from pytest import approx
+from sklearn.linear_model import LinearRegression
 from sklearn.metrics import accuracy_score, roc_auc_score
 
 from oodeel.eval.metrics import bench_metrics
@@ -106,3 +107,12 @@ def test_bench_metrics(in_value, out_value):
         step=1,
     )
     assert metrics_dict == metrics_dict_2
+
+    # Assert bench_metrics() returns no metric when wrong sklearn metric name
+    metrics = bench_metrics(scores, labels, metrics=[LinearRegression], threshold=0.3)
+    assert len(metrics) == 0
+
+    # Assert bench_metrics() returns no metric when no threshold is given
+    metrics = bench_metrics(scores, labels, metrics=[accuracy_score], threshold=None)
+    print(metrics, "DEBUG")
+    assert len(metrics) == 0


### PR DESCRIPTION
This PR contains two separate changes, aiming at improving the coverage:

* configuration options are added in `setup.cfg` for coverage tool: statements containing `NotImplementedError` and `except ImportError` are excluded from the coverage measure.
* unit tests for metrics are added. The file `eval/metrics.py` is now 100% covered by tests.