### PR TITLE
Remove tf.function in gradient operator to avoid multiple useless retracings

### DIFF
--- a/oodeel/utils/tf_operator.py
+++ b/oodeel/utils/tf_operator.py
@@ -108,7 +108,6 @@ class TFOperator(Operator):
         return tensor.numpy()
 
     @staticmethod
-    @tf.function
     def gradient(func: Callable, inputs: tf.Tensor, *args, **kwargs) -> tf.Tensor:
         """Compute gradients for a batch of samples.
 


### PR DESCRIPTION
The tf.function decorator on the gradient function operator was slowing down because of multiple retracings. Removing it speeds up the computation.

Adding tf.function on ODIN `input_perturbation()` function was the fastest option but input_perturbation() would not be framework-agnostic anymore.

As a temporary hotfix, we remove `@tf.function` decorator from `gradient` method to prevent useless raytracing. We will work on a more long-term solution in a future PR (see issue #52) .