### PR TITLE
Squeeze labels in fit_to_dataset function for Mahalanobis

### DIFF
--- a/oodeel/methods/mahalanobis.py
+++ b/oodeel/methods/mahalanobis.py
@@ -64,6 +64,9 @@ class Mahalanobis(OODBaseDetector):
             # if one hot encoded labels, take the argmax
             if len(_labels.shape) > 1 and _labels.shape[1] > 1:
                 _labels = self.op.argmax(self.op.flatten(_labels), 1)
+            # if labels in two dimensions, squeeze them
+            if len(_labels.shape) > 1:
+                _labels = self.op.reshape(_labels, [_labels.shape[0]])
             # get features
             _features = self.feature_extractor.predict(_images)
             _features = self.op.flatten(_features)


### PR DESCRIPTION
When retrieving the labels in Mahalanobis function `fit_to_dataset`, the labels must be in shape `(batch_size,)`. 
However when labels are in shape `(batch_size, 1)`, which can occur with some binary classification datasets, an error was raised because of incompatible shapes.

This PR fixes the issue: the labels are now squeezed to ensure that labels are of shape `(batch_size,)`.