### PR TITLE
Fix/feedback louis

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,8 @@ cd oodeel
 make prepare-dev
 ```
 
+> **Note:** If you want to install oodeel for a specific backend, replace the last line with either `make prepare-dev-torch` (for torch users) or `make prepare-dev-tf` (for tensorflow users).
+
 Now that *oodeel* is installed, here are some basic examples of what you can do with the available modules. See also the notebooks directory for more advanced examples.
 
 ## For benchmarking with one dataset as in-distribution and another as out-of-distribution

--- a/docs/index.md
+++ b/docs/index.md
@@ -31,7 +31,7 @@
 
 <!-- Short description of your library -->
 
-<b>Oodeel</b> is a library that performs post-hoc deep OOD detection on already trained neural network image classifiers. The philosophy of the library is to favor quality over quantity and to foster easy adoption. As a result, we provide a simple, compact and easily customizable API and carefully integrate and test each proposed baseline into a coherent framework that is designed to enable their use in tensorflow **and** pytorch. You can find the documentation [here](https://deel-ai.github.io/oodeel/).
+<b>Oodeel</b> is a library that performs post-hoc deep OOD detection on already trained neural network image classifiers. The philosophy of the library is to favor quality over quantity and to foster easy adoption. As a result, we provide a simple, compact and easily customizable API and carefully integrate and test each proposed baseline into a coherent framework that is designed to enable their use in tensorflow **and** pytorch.
 
 ```python
 from oodeel.methods import MLS
@@ -58,7 +58,7 @@ scores = mls.score(ds)
 
 # Tutorials
 
-We propose some tutorials to get familiar with the library and its API. See the Tutorial section of the [doc](https://deel-ai.github.io/oodeel/)
+We propose some tutorials to get familiar with the library and its API. See the Tutorial section of the doc.
 
 # Quick Start
 
@@ -87,7 +87,7 @@ ds_out = OODDataset(
   backend="tensorflow").prepare(batch_size)
 ```
 
-## For benchmarking with one dataset as in-distribution and another as out-of-distribution
+## For benchmarking with a classes subset as in-distribution and another classes subset as out-of-distribution
 
 Load a dataset and split it into an in-distribution dataset and ou-of-distribution dataset depending on its label values (a common practice of anomaly detection and open set recognition).
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -70,6 +70,8 @@ cd oodeel
 make prepare-dev
 ```
 
+> **Note:** If you want to install oodeel for a specific backend, replace the last line with either `make prepare-dev-torch` (for torch users) or `make prepare-dev-tf` (for tensorflow users).
+
 Now that *oodeel* is installed, here are some basic examples of what you can do with the available modules. See also the notebooks directory for more advanced examples.
 
 ## For benchmarking with one dataset as in-distribution and another as out-of-distribution

--- a/docs/pages/operator_tuto.md
+++ b/docs/pages/operator_tuto.md
@@ -1,7 +1,7 @@
 
 Oodeel is designed to work with both Tensorflow and Pytorch models. However, we wanted to avoid duplicate code as much as possible.
 
-Hence, we created the class `Operator` and the child classes `TFOperator` (API [here](/api/tf_operator)) and `TorchOperator` (API [here](/api/torch_operator)) to seamlessly perform basic operations on `tf.Tensor`or `torch.tensor`, for instance `mean`, `matmul`, `cat`, `softmax`...
+Hence, we created the class `Operator` and the child classes `TFOperator` (API [here](../api/tf_operator)) and `TorchOperator` (API [here](../api/torch_operator)) to seamlessly perform basic operations on `tf.Tensor`or `torch.tensor`, for instance `mean`, `matmul`, `cat`, `softmax`...
 
 !!! info
     Using this feature is not required to implement your own baselines with your favorite library, but only if you want your baseline to be usable with both Tensorflow and Pytorch.
@@ -43,7 +43,7 @@ elif backend == "tensorflow":
 ```
 
 !!! tip
-    If you do not know in advance from which library the input tensor will come from, there is a nice function we implemented for you: `is_from` (see [here](/api/utils))
+    If you do not know in advance from which library the input tensor will come from, there is a nice function we implemented for you: `is_from` (see [here](../api/utils))
 
 now it is possible to seamlessly use your `operator` to process your `tensor`:
 
@@ -110,4 +110,4 @@ def one_hot(
 
 #### Or simply User?
 
-If you just want to use Oodeel for your research, you can simply use your favorite lib and develop your brand new baseline like usual, following the tuto [here](/pages/implementing_baselines_tuto) without bothering with `Operator`.
+If you just want to use Oodeel for your research, you can simply use your favorite lib and develop your brand new baseline like usual, following the tuto [here](./implementing_baselines_tuto.ipynb) without bothering with `Operator`.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -7,7 +7,7 @@ nav:
     - "Getting started: Maximum Logit Score on MNIST": pages/getting_started.ipynb
     - Important Note On Feature Extractors: pages/feature_extractor_tuto.ipynb
     - OOD Baselines (Tensorflow):
-      - MLS/MSP: pages/getting_started.ipynb
+      - MLS/MSP: notebooks/tensorflow/demo_mls_msp_tf.ipynb
       - ODIN: notebooks/tensorflow/demo_odin_tf.ipynb
       - DKNN: notebooks/tensorflow/demo_dknn_tf.ipynb
       - VIM: notebooks/tensorflow/demo_vim_tf.ipynb
@@ -15,7 +15,7 @@ nav:
       - Entropy: notebooks/tensorflow/demo_entropy_tf.ipynb
       - Mahalanobis: notebooks/tensorflow/demo_mahalanobis_tf.ipynb
     - OOD Baselines (Torch):
-      - MLS/MSP: pages/getting_started.ipynb
+      - MLS/MSP: notebooks/torch/demo_mls_msp_torch.ipynb
       - ODIN: notebooks/torch/demo_odin_torch.ipynb
       - DKNN: notebooks/torch/demo_dknn_torch.ipynb
       - VIM: notebooks/torch/demo_vim_torch.ipynb


### PR DESCRIPTION
A few fixes in response to Louis feedback:

- [x] In the tutorial section of the doc: MLP / MSP lead to the Getting started tutorial, it would be more logical to return a link for separate torch and tf MLP / MSP notebooks.
- [x] In readme and index.md, add a note about `prepare-dev-torch` and `prepare-dev-tf` for users that want an installation for a specific backend.
- [x] In index.md, the title "For benchmarking with one dataset as in-distribution and another as out distribution" appears 2 times
- [x] Fix broken links in the doc, and remove the link leading to the main doc page from the main doc page (for instance "You can find the doc here" => useless)