### PR TITLE
FeatureExtractor.predict() can now return labels in addition to features

### DIFF
--- a/oodeel/extractor/feature_extractor.py
+++ b/oodeel/extractor/feature_extractor.py
@@ -105,13 +105,18 @@ class FeatureExtractor(ABC):
 
     @abstractmethod
     def predict(
-        self, dataset: Union[DatasetType, TensorType]
+        self,
+        dataset: Union[DatasetType, TensorType],
+        return_labels: bool = False,
     ) -> Union[TensorType, List[TensorType]]:
         """
         Projects input samples "inputs" into the feature space for a batched dataset
 
         Args:
             dataset (Union[DatasetType, TensorType]): iterable of tensor batches
+            return_labels (bool): if True, labels are returned in addition to the
+                features. If labels are one-hot encoded, the single label value is
+                returned instead.
 
         Returns:
             TensorType: features

--- a/oodeel/extractor/torch_feature_extractor.py
+++ b/oodeel/extractor/torch_feature_extractor.py
@@ -210,19 +210,19 @@ class TorchFeatureExtractor(FeatureExtractor):
     def predict(
         self,
         dataset: Union[DataLoader, ItemType],
-        detach: bool = True,
         return_labels: bool = False,
+        detach: bool = True,
         **kwargs
     ) -> Union[torch.Tensor, List[torch.Tensor]]:
         """Get the projection of the dataset in the feature space of self.model
 
         Args:
             dataset (Union[DataLoader, ItemType]): input dataset
-            detach (bool): if True, return features detached from the computational graph.
-                Defaults to True.
             return_labels (bool): if True, labels are returned in addition to the
                 features. If labels are one-hot encoded, the single label value is
                 returned instead.
+            detach (bool): if True, return features detached from the computational
+                graph. Defaults to True.
             kwargs (dict): additional arguments not considered for prediction
 
         Returns:

--- a/oodeel/methods/mahalanobis.py
+++ b/oodeel/methods/mahalanobis.py
@@ -59,23 +59,9 @@ class Mahalanobis(OODBaseDetector):
             fit_dataset (Union[TensorType, DatasetType]): input dataset (ID)
         """
         # extract features and labels
-        features = list()
-        labels = list()
-        for _images, _labels in fit_dataset:
-            # if one hot encoded labels, take the argmax
-            if len(_labels.shape) > 1 and _labels.shape[1] > 1:
-                _labels = self.op.argmax(self.op.flatten(_labels), 1)
-            # if labels in two dimensions, squeeze them
-            if len(_labels.shape) > 1:
-                _labels = self.op.reshape(_labels, [_labels.shape[0]])
-            # get features
-            _features = self.feature_extractor.predict(_images)
-            _features = self.op.flatten(_features)
-
-            labels.append(_labels)
-            features.append(_features)
-        labels = self.op.cat(labels)
-        features = self.op.cat(features)
+        features, labels = self.feature_extractor.predict(
+            fit_dataset, return_labels=True
+        )
 
         # unique sorted classes
         self._classes = np.sort(np.unique(self.op.convert_to_numpy(labels)))

--- a/oodeel/types/__init__.py
+++ b/oodeel/types/__init__.py
@@ -61,14 +61,15 @@ if len(avail_lib) == 2:
         torch.Tensor,
         np.ndarray,
         tuple,
+        list,
         dict,
     ]
 
 elif "tensorflow" in avail_lib:
     DatasetType = Type[tf.data.Dataset]
     TensorType = Union[tf.Tensor, np.ndarray]
-    ItemType = Union[tf.Tensor, np.ndarray, tuple, dict]
+    ItemType = Union[tf.Tensor, np.ndarray, tuple, list, dict]
 elif "torch" in avail_lib:
     DatasetType = Type[torch.utils.data.DataLoader]
     TensorType = Union[torch.Tensor, np.ndarray]
-    ItemType = Union[torch.Tensor, np.ndarray, tuple, dict]
+    ItemType = Union[torch.Tensor, np.ndarray, tuple, list, dict]

--- a/tests/tests_torch/tools_torch.py
+++ b/tests/tests_torch/tools_torch.py
@@ -141,7 +141,11 @@ def generate_data(x_shape=(3, 32, 32), num_labels=10, samples=100, one_hot=True)
     return x, y
 
 
-def generate_data_torch(x_shape=(3, 32, 32), num_labels=10, samples=100, one_hot=True):
+def generate_data_torch(
+    x_shape=(3, 32, 32), num_labels=10, samples=100, one_hot=True, with_labels=True
+):
     x, y = generate_data(x_shape, num_labels, samples, one_hot)
-    dataset = TensorDataset(torch.Tensor(x), torch.Tensor(y))
-    return dataset
+    if with_labels:
+        return TensorDataset(torch.Tensor(x), torch.Tensor(y))
+    else:
+        return TensorDataset(torch.Tensor(x))


### PR DESCRIPTION
A new bool argument `return_labels` is introduced in `FeatureExtractor.predict()`. If True, the function returns a tuple `(features, labels)`. If False, the function behaves as previously: only the features are returned as a tensor.

Special cases:
- if no label is given in the dataset, `None` is returned
- if labels are one-hot encoded, they are reduced to single values.