### PR TITLE
docs: replace mathjax extension with katex to render latex

### DIFF
--- a/docs/js/custom.js
+++ b/docs/js/custom.js
@@ -1,12 +1,10 @@
-window.MathJax = {
-  tex: {
-    inlineMath: [["\\(", "\\)"]],
-    displayMath: [["\\[", "\\]"]],
-    processEscapes: true,
-    processEnvironments: true,
-  },
-  options: {
-    ignoreHtmlClass: ".*|",
-    processHtmlClass: "arithmatex"
-  },
-};
+document$.subscribe(({ body }) => {
+  renderMathInElement(body, {
+    delimiters: [
+      { left: "$$",  right: "$$",  display: true },
+      { left: "$",   right: "$",   display: false },
+      { left: "\\(", right: "\\)", display: false },
+      { left: "\\[", right: "\\]", display: true }
+    ],
+  })
+})

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -78,8 +78,6 @@ markdown_extensions:
   - footnotes
   - extra
   - admonition
-  - pymdownx.arithmatex:
-      generic: true
   - pymdownx.highlight
   - pymdownx.superfences
   - codehilite
@@ -97,11 +95,11 @@ markdown_extensions:
 
 extra_css:
   - css/custom.css
-
+  - https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.16.7/katex.min.css
 extra_javascript:
-  - https://polyfill.io/v3/polyfill.min.js?features=es6
-  - https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js
   - js/custom.js
+  - https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.16.7/katex.min.js
+  - https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.16.7/contrib/auto-render.min.js
 
 repo_name: "deel-ai/oodeel"
 repo_url: "https://github.com/deel-ai/oodeel"


### PR DESCRIPTION
Latex equations rendered incorrectly on some notebooks in mkdocs documentation. The problem is solved by using KaTex intead of MathJax extension for mkdocs.

I followed these instructions: 

https://squidfunk.github.io/mkdocs-material/reference/math/#configuration