### PR TITLE
Feat/patch permutation

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,8 @@ scores, info = mls.score(ds) # ds is a tf.data.Dataset or a torch.DataLoader
 - [Contributing](#contributing)
 - [See Also](#see-also)
 - [Acknowledgments](#acknowledgments)
-- [Creator](#creator)
+- [Creators](#creators)
+- [Citation](#citation)
 - [License](#license)
 
 # Installation
@@ -225,6 +226,19 @@ This project received funding from the French ”Investing for the Future – PI
 
 The library was created by Paul Novello to streamline DEEL research on post-hoc deep OOD methods and foster their adoption by DEEL industrial partners. He was soon joined by Yann Pequignot, Yannick Prudent, Corentin Friedrich and Matthieu Le Goff.
 
+# Citation
+
+If you use OODEEL for your research project, please consider citing:
+```
+@misc{oodeel,
+  author = {Novello, Paul and Prudent, Yannick and Friedrich, Corentin and Pequignot, Yann and Le Goff, Matthieu},
+  title = {OODEEL, a simple, compact, and hackable post-hoc deep OOD detection for already trained tensorflow or pytorch image classifiers.},
+  year = {2023},
+  publisher = {GitHub},
+  journal = {GitHub repository},
+  howpublished = {\url{https://github.com/deel-ai/oodeel}},
+}
+```
 # License
 
 The package is released under [MIT license](LICENSE).

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@
 
 <!-- Short description of your library -->
 
-<b>Oodeel</b> is a library that performs post-hoc deep OOD detection on **any** already trained neural network image classifiers. The philosophy of the library is to favor quality over quantity and to foster easy adoption. As a result, we provide a simple, compact and easily customizable API and carefully integrate and test each proposed baseline into a coherent framework that is designed to enable their use in tensorflow **and** pytorch. You can find the documentation [here](https://deel-ai.github.io/oodeel/).
+<b>Oodeel</b> is a library that performs post-hoc deep OOD (Out-of-Distribution) detection on already trained neural network image classifiers. The philosophy of the library is to favor quality over quantity and to foster easy adoption. As a result, we provide a simple, compact and easily customizable API and carefully integrate and test each proposed baseline into a coherent framework that is designed to enable their use in tensorflow **and** pytorch. You can find the documentation [here](https://deel-ai.github.io/oodeel/).
 
 ```python
 from oodeel.methods import MLS

--- a/README.md
+++ b/README.md
@@ -12,23 +12,17 @@
 <!-- Badge section -->
 <div align="center">
     <a href="#">
-        <img src="https://img.shields.io/badge/python-3.8%2B-blue">
-    </a>
+        <img src="https://img.shields.io/badge/python-3.8%2B-blue"></a>
     <a href="https://github.com/deel-ai/oodeel/actions/workflows/python-linters.yml">
-        <img alt="Flake8" src="https://github.com/deel-ai/oodeel/actions/workflows/python-linters.yml/badge.svg">
-    </a>
+        <img alt="Flake8" src="https://github.com/deel-ai/oodeel/actions/workflows/python-linters.yml/badge.svg"></a>
     <a href="https://github.com/deel-ai/oodeel/actions/workflows/python-tests-tf.yml">
-        <img alt="Tests tf" src="https://github.com/deel-ai/oodeel/actions/workflows/python-tests-tf.yml/badge.svg">
-    </a>
+        <img alt="Tests tf" src="https://github.com/deel-ai/oodeel/actions/workflows/python-tests-tf.yml/badge.svg"></a>
     <a href="https://github.com/deel-ai/oodeel/actions/workflows/python-tests-torch.yml">
-        <img alt="Tests torch" src="https://github.com/deel-ai/oodeel/actions/workflows/python-tests-torch.yml/badge.svg">
-    </a>
+        <img alt="Tests torch" src="https://github.com/deel-ai/oodeel/actions/workflows/python-tests-torch.yml/badge.svg"></a>
     <a href="https://github.com/deel-ai/oodeel/actions/workflows/python-coverage-shield.yml">
-        <img alt="Coverage" src="https://github.com/deel-ai/oodeel/raw/gh-shields/coverage.svg">
-    </a>
+        <img alt="Coverage" src="https://github.com/deel-ai/oodeel/raw/gh-shields/coverage.svg"></a>
     <a href="https://github.com/deel-ai/oodeel/blob/master/LICENSE">
-        <img alt="License MIT" src="https://img.shields.io/badge/License-MIT-efefef">
-    </a>
+        <img alt="License MIT" src="https://img.shields.io/badge/License-MIT-efefef"></a>
 </div>
 <br>
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -31,7 +31,7 @@
 
 <!-- Short description of your library -->
 
-<b>Oodeel</b> is a library that performs post-hoc deep OOD detection on already trained neural network image classifiers. The philosophy of the library is to favor quality over quantity and to foster easy adoption. As a result, we provide a simple, compact and easily customizable API and carefully integrate and test each proposed baseline into a coherent framework that is designed to enable their use in tensorflow **and** pytorch.
+<b>Oodeel</b> is a library that performs post-hoc deep OOD (Out-of-Distribution) detection on already trained neural network image classifiers. The philosophy of the library is to favor quality over quantity and to foster easy adoption. As a result, we provide a simple, compact and easily customizable API and carefully integrate and test each proposed baseline into a coherent framework that is designed to enable their use in tensorflow **and** pytorch.
 
 ```python
 from oodeel.methods import MLS

--- a/oodeel/preprocess/__init__.py
+++ b/oodeel/preprocess/__init__.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+# Copyright IRT Antoine de Saint Exupéry et Université Paul Sabatier Toulouse III - All
+# rights reserved. DEEL is a research program operated by IVADO, IRT Saint Exupéry,
+# CRIAQ and ANITI - https://www.deel.ai/
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+try:
+    from .tf_preprocess import TFRandomPatchPermutation
+except ImportError:
+    pass
+
+try:
+    from .torch_preprocess import TorchRandomPatchPermutation
+except ImportError:
+    pass

--- a/oodeel/preprocess/tf_preprocess.py
+++ b/oodeel/preprocess/tf_preprocess.py
@@ -1,0 +1,95 @@
+# -*- coding: utf-8 -*-
+# Copyright IRT Antoine de Saint Exupéry et Université Paul Sabatier Toulouse III - All
+# rights reserved. DEEL is a research program operated by IVADO, IRT Saint Exupéry,
+# CRIAQ and ANITI - https://www.deel.ai/
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+import numpy as np
+import tensorflow as tf
+
+from ..types import Optional
+from ..types import Tuple
+
+
+class TFRandomPatchPermutation:
+    def __init__(self, patch_size: Tuple[int] = (8, 8)):
+        """Randomly permute the patches of an image. This transformation is used in NMD
+        paper to artificially craft OOD data from ID images.
+
+        Source (NMD paper):
+            "Neural Mean Discrepancy for Efficient Out-of-Distribution Detection"
+            [link](https://arxiv.org/pdf/2104.11408.pdf)
+
+        Args:
+            patch_size (Tuple[int], optional): Patch dimensions (h, w), should be
+                divisors of the image dimensions (H, W). Defaults to (8, 8).
+        """
+        self.patch_size = patch_size
+
+    def __call__(self, tensor: tf.Tensor, seed: Optional[int] = None):
+        """Apply random patch permutation.
+
+        Args:
+            tensor (tf.Tensor): Tensor of shape [H, W, C]
+            seed (Optinal[int]): Seed number to set for the permutation if not None.
+
+        Returns:
+            tf.Tensor: Transformed tensor.
+        """
+        h, w = self.patch_size
+        H, W, C = tensor.shape
+        tensor_ = tensor
+
+        # raise warning if patch dimensions are not divisors of image dimensions
+        if H % h != 0:
+            print(
+                f"Warning! Patch height ({h}) should be a divisor of the image height"
+                + f" ({H}). Zero padding will be added to get the correct output shape."
+            )
+            tensor_ = tensor[: -(H % h)]
+        if W % w != 0:
+            print(
+                f"Warning! Patch width ({w}) should be a divisor of the image width"
+                + f" ({W}). Zero padding will be added to get the correct output shape."
+            )
+            tensor_ = tensor_[:, : -(W % w)]
+
+        # === patch permutation ===
+        # divide the batch of images into non-overlapping patches
+        # => [num_patches, h * w, C]
+        u = tf.transpose(
+            tf.reshape(tensor_, (H // h, h, W // w, w, C)), (0, 2, 1, 3, 4)
+        )
+        u = tf.reshape(u, (-1, h * w, C))
+
+        # permute the patches of each image in the batch
+        # => [num_patches, h * w, C]
+        # Note: we use numpy rng for deterministic index shuffling because
+        #       `tf.stateless_shuffle` is still experimental
+        g = np.random.default_rng(seed=seed)
+        indices = np.arange(u.shape[0])
+        g.shuffle(indices)
+        pu = tf.gather(u, indices)
+
+        # fold the permuted patches back together
+        # => [H, W, C]
+        f = tf.transpose(tf.reshape(pu, (H // h, W // w, h, w, C)), (0, 2, 1, 3, 4))
+        f = tf.reshape(f, tensor_.shape)
+        f = tf.pad(f, tf.constant([[0, H % h], [0, W % w], [0, 0]]))
+        return f

--- a/oodeel/preprocess/torch_preprocess.py
+++ b/oodeel/preprocess/torch_preprocess.py
@@ -1,0 +1,97 @@
+# -*- coding: utf-8 -*-
+# Copyright IRT Antoine de Saint Exupéry et Université Paul Sabatier Toulouse III - All
+# rights reserved. DEEL is a research program operated by IVADO, IRT Saint Exupéry,
+# CRIAQ and ANITI - https://www.deel.ai/
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+import torch
+import torch.nn.functional as F
+
+from ..types import Optional
+from ..types import Tuple
+
+
+class TorchRandomPatchPermutation:
+    def __init__(self, patch_size: Tuple[int] = (8, 8)):
+        """Randomly permute the patches of an image. This transformation is used in NMD
+        paper to artificially craft OOD data from ID images.
+
+        Source (NMD paper):
+            "Neural Mean Discrepancy for Efficient Out-of-Distribution Detection"
+            [link](https://arxiv.org/pdf/2104.11408.pdf)
+
+        Args:
+            patch_size (Tuple[int], optional): Patch dimensions (h, w), should be
+                divisors of the image dimensions (H, W). Defaults to (8, 8).
+        """
+        self.patch_size = patch_size
+
+    def __call__(self, tensor: torch.Tensor, seed: Optional[int] = None):
+        """Apply random patch permutation.
+
+        Args:
+            tensor (torch.Tensor): Tensor of shape [C, H, W]
+            seed (Optinal[int]): Seed number to set for the permutation if not None.
+
+        Returns:
+            torch.Tensor: Transformed tensor.
+        """
+        h, w = self.patch_size
+        H, W, _ = tensor.shape
+
+        # set generator if seed is not None
+        g = None
+        if seed is not None:
+            g = torch.Generator(device=tensor.device)
+            g.manual_seed(seed)
+
+        # raise warning if patch dimensions are not divisors of image dimensions
+        if H % h != 0:
+            print(
+                f"Warning! Patch height ({h}) should be a divisor of the image height"
+                + f" ({H}). Zero padding will be added to get the correct output shape."
+            )
+        if W % w != 0:
+            print(
+                f"Warning! Patch width ({w}) should be a divisor of the image width"
+                + f" ({W}). Zero padding will be added to get the correct output shape."
+            )
+
+        # === patch permutation ===
+        # [C, H, W] => [1, C, H, W]
+        x = tensor.unsqueeze(0)
+        # divide the batch of images into non-overlapping patches
+        # => [1, h * w, num_patches]
+        u = F.unfold(x, kernel_size=self.patch_size, stride=self.patch_size, padding=0)
+        # permute the patches of each image in the batch
+        # => [1, h * w, num_patches]
+        pu = torch.cat(
+            [b_[:, torch.randperm(b_.shape[-1], generator=g)][None, ...] for b_ in u],
+            dim=0,
+        )
+        # fold the permuted patches back together
+        # => [1, C, H, W]
+        f = F.fold(
+            pu,
+            x.shape[-2:],
+            kernel_size=self.patch_size,
+            stride=self.patch_size,
+            padding=0,
+        )
+        return f.squeeze(0)

--- a/setup.cfg
+++ b/setup.cfg
@@ -50,6 +50,7 @@ deps =
     protobuf <=3.20
     pandas
     seaborn
+    requests
     plotly == 5.15.0
     tf24: tensorflow ~= 2.4.0
     tf24: tensorflow_datasets ~= 4.3.0
@@ -84,6 +85,7 @@ deps =
     protobuf <=3.20
     pandas
     seaborn
+    requests
     plotly == 5.15.0
     torch17: torch == 1.7.1+cpu
     torch17: torchvision == 0.8.2+cpu

--- a/tests/tests_tensorflow/preprocess/test_tf_preprocess.py
+++ b/tests/tests_tensorflow/preprocess/test_tf_preprocess.py
@@ -1,0 +1,112 @@
+# -*- coding: utf-8 -*-
+# Copyright IRT Antoine de Saint Exupéry et Université Paul Sabatier Toulouse III - All
+# rights reserved. DEEL is a research program operated by IVADO, IRT Saint Exupéry,
+# CRIAQ and ANITI - https://www.deel.ai/
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+import numpy as np
+import pytest
+import tensorflow as tf
+
+from oodeel.preprocess import TFRandomPatchPermutation
+from oodeel.types import Tuple
+from tests.tests_tensorflow.tools_tf import almost_equal
+
+
+@pytest.mark.parametrize(
+    "patch_size, p_tensor_gt",
+    [
+        (
+            (2, 2),
+            np.array(
+                [
+                    [
+                        [69.0, 70.0, 9.0, 10.0, 41.0, 42.0, 43.0, 44.0, 89.0, 90.0],
+                        [79.0, 80.0, 19.0, 20.0, 51.0, 52.0, 53.0, 54.0, 99.0, 100.0],
+                        [5.0, 6.0, 87.0, 88.0, 23.0, 24.0, 63.0, 64.0, 85.0, 86.0],
+                        [15.0, 16.0, 97.0, 98.0, 33.0, 34.0, 73.0, 74.0, 95.0, 96.0],
+                        [7.0, 8.0, 83.0, 84.0, 27.0, 28.0, 1.0, 2.0, 81.0, 82.0],
+                        [17.0, 18.0, 93.0, 94.0, 37.0, 38.0, 11.0, 12.0, 91.0, 92.0],
+                        [45.0, 46.0, 67.0, 68.0, 47.0, 48.0, 25.0, 26.0, 21.0, 22.0],
+                        [55.0, 56.0, 77.0, 78.0, 57.0, 58.0, 35.0, 36.0, 31.0, 32.0],
+                        [65.0, 66.0, 49.0, 50.0, 29.0, 30.0, 3.0, 4.0, 61.0, 62.0],
+                        [75.0, 76.0, 59.0, 60.0, 39.0, 40.0, 13.0, 14.0, 71.0, 72.0],
+                    ],
+                    [
+                        [69.0, 70.0, 9.0, 10.0, 41.0, 42.0, 43.0, 44.0, 89.0, 90.0],
+                        [79.0, 80.0, 19.0, 20.0, 51.0, 52.0, 53.0, 54.0, 99.0, 100.0],
+                        [5.0, 6.0, 87.0, 88.0, 23.0, 24.0, 63.0, 64.0, 85.0, 86.0],
+                        [15.0, 16.0, 97.0, 98.0, 33.0, 34.0, 73.0, 74.0, 95.0, 96.0],
+                        [7.0, 8.0, 83.0, 84.0, 27.0, 28.0, 1.0, 2.0, 81.0, 82.0],
+                        [17.0, 18.0, 93.0, 94.0, 37.0, 38.0, 11.0, 12.0, 91.0, 92.0],
+                        [45.0, 46.0, 67.0, 68.0, 47.0, 48.0, 25.0, 26.0, 21.0, 22.0],
+                        [55.0, 56.0, 77.0, 78.0, 57.0, 58.0, 35.0, 36.0, 31.0, 32.0],
+                        [65.0, 66.0, 49.0, 50.0, 29.0, 30.0, 3.0, 4.0, 61.0, 62.0],
+                        [75.0, 76.0, 59.0, 60.0, 39.0, 40.0, 13.0, 14.0, 71.0, 72.0],
+                    ],
+                ]
+            ),
+        ),
+        (
+            (4, 3),
+            np.array(
+                [
+                    [
+                        [41.0, 42.0, 43.0, 7.0, 8.0, 9.0, 47.0, 48.0, 49.0, 0.0],
+                        [51.0, 52.0, 53.0, 17.0, 18.0, 19.0, 57.0, 58.0, 59.0, 0.0],
+                        [61.0, 62.0, 63.0, 27.0, 28.0, 29.0, 67.0, 68.0, 69.0, 0.0],
+                        [71.0, 72.0, 73.0, 37.0, 38.0, 39.0, 77.0, 78.0, 79.0, 0.0],
+                        [44.0, 45.0, 46.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 0.0],
+                        [54.0, 55.0, 56.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0, 0.0],
+                        [64.0, 65.0, 66.0, 21.0, 22.0, 23.0, 24.0, 25.0, 26.0, 0.0],
+                        [74.0, 75.0, 76.0, 31.0, 32.0, 33.0, 34.0, 35.0, 36.0, 0.0],
+                        [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+                        [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+                    ],
+                    [
+                        [41.0, 42.0, 43.0, 7.0, 8.0, 9.0, 47.0, 48.0, 49.0, 0.0],
+                        [51.0, 52.0, 53.0, 17.0, 18.0, 19.0, 57.0, 58.0, 59.0, 0.0],
+                        [61.0, 62.0, 63.0, 27.0, 28.0, 29.0, 67.0, 68.0, 69.0, 0.0],
+                        [71.0, 72.0, 73.0, 37.0, 38.0, 39.0, 77.0, 78.0, 79.0, 0.0],
+                        [44.0, 45.0, 46.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 0.0],
+                        [54.0, 55.0, 56.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0, 0.0],
+                        [64.0, 65.0, 66.0, 21.0, 22.0, 23.0, 24.0, 25.0, 26.0, 0.0],
+                        [74.0, 75.0, 76.0, 31.0, 32.0, 33.0, 34.0, 35.0, 36.0, 0.0],
+                        [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+                        [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+                    ],
+                ]
+            ),
+        ),
+    ],
+)
+def test_random_patch_permutation(patch_size: Tuple[int], p_tensor_gt: np.ndarray):
+    h, w, c = 10, 10, 2
+    dummy_image = (
+        np.arange(1, 101).reshape((h, w, 1)).repeat(c, axis=-1).astype(np.float32)
+    )
+    tensor = tf.convert_to_tensor(dummy_image)
+    transform = TFRandomPatchPermutation(patch_size=patch_size)
+    p_tensor = transform(tensor, seed=0)  # set seed for deterministic behaviour
+
+    # shape assert
+    assert p_tensor.shape == tensor.shape
+    # compare tensors
+    p_tensor_gt = p_tensor_gt.transpose(1, 2, 0)
+    assert almost_equal(p_tensor.numpy(), p_tensor_gt)

--- a/tests/tests_torch/preprocess/test_torch_preprocess.py
+++ b/tests/tests_torch/preprocess/test_torch_preprocess.py
@@ -1,0 +1,111 @@
+# -*- coding: utf-8 -*-
+# Copyright IRT Antoine de Saint Exupéry et Université Paul Sabatier Toulouse III - All
+# rights reserved. DEEL is a research program operated by IVADO, IRT Saint Exupéry,
+# CRIAQ and ANITI - https://www.deel.ai/
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+import numpy as np
+import pytest
+import torch
+
+from oodeel.preprocess import TorchRandomPatchPermutation
+from oodeel.types import Tuple
+from tests.tests_torch.tools_torch import almost_equal
+
+
+@pytest.mark.parametrize(
+    "patch_size, p_tensor_gt",
+    [
+        (
+            (2, 2),
+            np.array(
+                [
+                    [
+                        [69.0, 70.0, 63.0, 64.0, 23.0, 24.0, 65.0, 66.0, 21.0, 22.0],
+                        [79.0, 80.0, 73.0, 74.0, 33.0, 34.0, 75.0, 76.0, 31.0, 32.0],
+                        [89.0, 90.0, 43.0, 44.0, 27.0, 28.0, 49.0, 50.0, 45.0, 46.0],
+                        [99.0, 100.0, 53.0, 54.0, 37.0, 38.0, 59.0, 60.0, 55.0, 56.0],
+                        [83.0, 84.0, 5.0, 6.0, 61.0, 62.0, 3.0, 4.0, 85.0, 86.0],
+                        [93.0, 94.0, 15.0, 16.0, 71.0, 72.0, 13.0, 14.0, 95.0, 96.0],
+                        [41.0, 42.0, 47.0, 48.0, 29.0, 30.0, 25.0, 26.0, 67.0, 68.0],
+                        [51.0, 52.0, 57.0, 58.0, 39.0, 40.0, 35.0, 36.0, 77.0, 78.0],
+                        [7.0, 8.0, 9.0, 10.0, 81.0, 82.0, 87.0, 88.0, 1.0, 2.0],
+                        [17.0, 18.0, 19.0, 20.0, 91.0, 92.0, 97.0, 98.0, 11.0, 12.0],
+                    ],
+                    [
+                        [69.0, 70.0, 63.0, 64.0, 23.0, 24.0, 65.0, 66.0, 21.0, 22.0],
+                        [79.0, 80.0, 73.0, 74.0, 33.0, 34.0, 75.0, 76.0, 31.0, 32.0],
+                        [89.0, 90.0, 43.0, 44.0, 27.0, 28.0, 49.0, 50.0, 45.0, 46.0],
+                        [99.0, 100.0, 53.0, 54.0, 37.0, 38.0, 59.0, 60.0, 55.0, 56.0],
+                        [83.0, 84.0, 5.0, 6.0, 61.0, 62.0, 3.0, 4.0, 85.0, 86.0],
+                        [93.0, 94.0, 15.0, 16.0, 71.0, 72.0, 13.0, 14.0, 95.0, 96.0],
+                        [41.0, 42.0, 47.0, 48.0, 29.0, 30.0, 25.0, 26.0, 67.0, 68.0],
+                        [51.0, 52.0, 57.0, 58.0, 39.0, 40.0, 35.0, 36.0, 77.0, 78.0],
+                        [7.0, 8.0, 9.0, 10.0, 81.0, 82.0, 87.0, 88.0, 1.0, 2.0],
+                        [17.0, 18.0, 19.0, 20.0, 91.0, 92.0, 97.0, 98.0, 11.0, 12.0],
+                    ],
+                ]
+            ),
+        ),
+        (
+            (4, 3),
+            np.array(
+                [
+                    [
+                        [7.0, 8.0, 9.0, 47.0, 48.0, 49.0, 41.0, 42.0, 43.0, 0.0],
+                        [17.0, 18.0, 19.0, 57.0, 58.0, 59.0, 51.0, 52.0, 53.0, 0.0],
+                        [27.0, 28.0, 29.0, 67.0, 68.0, 69.0, 61.0, 62.0, 63.0, 0.0],
+                        [37.0, 38.0, 39.0, 77.0, 78.0, 79.0, 71.0, 72.0, 73.0, 0.0],
+                        [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 44.0, 45.0, 46.0, 0.0],
+                        [11.0, 12.0, 13.0, 14.0, 15.0, 16.0, 54.0, 55.0, 56.0, 0.0],
+                        [21.0, 22.0, 23.0, 24.0, 25.0, 26.0, 64.0, 65.0, 66.0, 0.0],
+                        [31.0, 32.0, 33.0, 34.0, 35.0, 36.0, 74.0, 75.0, 76.0, 0.0],
+                        [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+                        [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+                    ],
+                    [
+                        [7.0, 8.0, 9.0, 47.0, 48.0, 49.0, 41.0, 42.0, 43.0, 0.0],
+                        [17.0, 18.0, 19.0, 57.0, 58.0, 59.0, 51.0, 52.0, 53.0, 0.0],
+                        [27.0, 28.0, 29.0, 67.0, 68.0, 69.0, 61.0, 62.0, 63.0, 0.0],
+                        [37.0, 38.0, 39.0, 77.0, 78.0, 79.0, 71.0, 72.0, 73.0, 0.0],
+                        [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 44.0, 45.0, 46.0, 0.0],
+                        [11.0, 12.0, 13.0, 14.0, 15.0, 16.0, 54.0, 55.0, 56.0, 0.0],
+                        [21.0, 22.0, 23.0, 24.0, 25.0, 26.0, 64.0, 65.0, 66.0, 0.0],
+                        [31.0, 32.0, 33.0, 34.0, 35.0, 36.0, 74.0, 75.0, 76.0, 0.0],
+                        [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+                        [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+                    ],
+                ]
+            ),
+        ),
+    ],
+)
+def test_random_patch_permutation(patch_size: Tuple[int], p_tensor_gt: np.ndarray):
+    c, h, w = 2, 10, 10
+    dummy_image = (
+        np.arange(1, 101).reshape((1, h, w)).repeat(c, axis=0).astype(np.float32)
+    )
+    tensor = torch.Tensor(dummy_image)
+    transform = TorchRandomPatchPermutation(patch_size=patch_size)
+    p_tensor = transform(tensor, seed=0)  # set seed for deterministic behaviour
+
+    # shape assert
+    assert p_tensor.shape == tensor.shape
+    # compare tensors
+    assert almost_equal(p_tensor.numpy(), p_tensor_gt)


### PR DESCRIPTION
## Feature

Add `TFRandomPatchPermutation` and `TorchRandomPatchPermutation` transformations, that will split an image into patches, shuffle these patches, and then reconstruct the image. This way of preprocessing is used in the paper \[["Neural Mean Discrepancy for Efficient Out-of-Distribution Detection"](https://openaccess.thecvf.com/content/CVPR2022/html/Dong_Neural_Mean_Discrepancy_for_Efficient_Out-of-Distribution_Detection_CVPR_2022_paper.html)\] to craft OOD images from an ID dataset, and can be useful for benchmarks.

### Note

The case where a patch dimension is not a diviser of the corresponding image dimension is handled, by adding zero padding:

- `patch_size = (8, 8)`
![image](https://github.com/deel-ai/oodeel/assets/60829186/3f99926e-69cd-4dfe-866a-221fc996dd08)

- `patch_size = (10, 10)` (not a divisor of 32)
![image](https://github.com/deel-ai/oodeel/assets/60829186/5b67be55-aaef-4695-b396-f7eafdde3a3c)

## How to use it

```python
from oodeel.preprocess import TorchRandomPatchPermutation

mnist_train = OODDataset(
    dataset_id='CIFAR10', backend="torch",
    load_kwargs={"root": data_path, "train": True, "download": True}
)

def preprocess_fn(*inputs):
    """Normalize images in [0, 1] + apply random patch permutation.
    """
    x = inputs[0] / 255.0
    # split image in patches of size (8, 8)
    x = TorchRandomPatchPermutation((8, 8))(x)
    return tuple([x] + list(inputs[1:]))

ds_out = mnist_train.prepare(batch_size=128, preprocess_fn=preprocess_fn)