### PR TITLE
Fix/methods

### DIFF
--- a/oodeel/datasets/ooddataset.py
+++ b/oodeel/datasets/ooddataset.py
@@ -265,7 +265,7 @@ class OODDataset(object):
         with_ood_labels: bool = False,
         with_labels: bool = True,
         shuffle: bool = False,
-        shuffle_buffer_size: Optional[int] = None,
+        **kwargs_prepare,
     ) -> DatasetType:
         """Prepare self.data for scoring or training
 
@@ -282,9 +282,9 @@ class OODDataset(object):
                 Defaults to True.
             shuffle (bool, optional): To shuffle the returned dataset or not.
                 Defaults to False.
-            shuffle_buffer_size (int, optional): (TF only) Size of the shuffle buffer.
-                If None, taken as the number of samples in the dataset.
-                Defaults to None.
+            kwargs_prepare (dict): Additional parameters to be passed to the
+                data_handler.prepare_for_training method.
+
 
         Returns:
             DatasetType: prepared dataset
@@ -323,7 +323,7 @@ class OODDataset(object):
             preprocess_fn=preprocess_fn,
             augment_fn=augment_fn,
             output_keys=keys,
-            shuffle_buffer_size=shuffle_buffer_size,
+            **kwargs_prepare,
         )
 
         return dataset

--- a/oodeel/datasets/torch_data_handler.py
+++ b/oodeel/datasets/torch_data_handler.py
@@ -569,6 +569,7 @@ class TorchDataHandler(DataHandler):
         output_keys: Optional[list] = None,
         dict_based_fns: bool = False,
         shuffle_buffer_size: Optional[int] = None,
+        num_workers: int = 8,
     ) -> DataLoader:
         """Prepare a DataLoader for training
 
@@ -587,6 +588,7 @@ class TorchDataHandler(DataHandler):
             shuffle_buffer_size (int, optional): Size of the shuffle buffer. Not used
                 in torch because we only rely on Map-Style datasets. Still as argument
                 for API consistency. Defaults to None.
+            num_workers (int, optional): Number of workers to use for the dataloader.
 
         Returns:
             DataLoader: dataloader
@@ -621,6 +623,7 @@ class TorchDataHandler(DataHandler):
             batch_size=batch_size,
             shuffle=shuffle,
             collate_fn=collate_fn,
+            num_workers=num_workers,
         )
         return loader
 

--- a/oodeel/extractor/feature_extractor.py
+++ b/oodeel/extractor/feature_extractor.py
@@ -114,6 +114,7 @@ class FeatureExtractor(ABC):
         self,
         dataset: Union[ItemType, DatasetType],
         postproc_fns: Optional[List[Callable]] = None,
+        verbose: bool = False,
         **kwargs,
     ) -> Tuple[List[TensorType], dict]:
         """Get the projection of the dataset in the feature space of self.model
@@ -122,6 +123,7 @@ class FeatureExtractor(ABC):
             dataset (Union[ItemType, DatasetType]): input dataset
             postproc_fns (Optional[Callable]): postprocessing function to apply to each
                 feature immediately after forward. Default to None.
+            verbose (bool): if True, display a progress bar. Defaults to False.
             kwargs (dict): additional arguments not considered for prediction
 
         Returns:

--- a/oodeel/extractor/keras_feature_extractor.py
+++ b/oodeel/extractor/keras_feature_extractor.py
@@ -24,6 +24,7 @@ from typing import get_args
 from typing import Optional
 
 import tensorflow as tf
+from tqdm import tqdm
 
 from ..datasets.tf_data_handler import TFDataHandler
 from ..types import Callable
@@ -190,6 +191,7 @@ class KerasFeatureExtractor(FeatureExtractor):
         self,
         dataset: Union[ItemType, tf.data.Dataset],
         postproc_fns: Optional[List[Callable]] = None,
+        verbose: bool = False,
         **kwargs,
     ) -> Tuple[List[tf.Tensor], dict]:
         """Get the projection of the dataset in the feature space of self.model
@@ -198,6 +200,7 @@ class KerasFeatureExtractor(FeatureExtractor):
             dataset (Union[ItemType, tf.data.Dataset]): input dataset
             postproc_fns (Optional[Callable]): postprocessing function to apply to each
                 feature immediately after forward. Default to None.
+            verbose (bool): if True, display a progress bar. Defaults to False.
             kwargs (dict): additional arguments not considered for prediction
 
         Returns:
@@ -218,7 +221,7 @@ class KerasFeatureExtractor(FeatureExtractor):
             features = [None for i in range(len(self.feature_layers_id))]
             logits = None
             contains_labels = TFDataHandler.get_item_length(dataset) > 1
-            for elem in dataset:
+            for elem in tqdm(dataset, desc="Predicting", disable=not verbose):
                 tensor = TFDataHandler.get_input_from_dataset_item(elem)
                 features_batch, logits_batch = self.predict_tensor(tensor, postproc_fns)
 

--- a/oodeel/extractor/torch_feature_extractor.py
+++ b/oodeel/extractor/torch_feature_extractor.py
@@ -27,6 +27,7 @@ from typing import Optional
 import torch
 from torch import nn
 from torch.utils.data import DataLoader
+from tqdm import tqdm
 
 from ..datasets.torch_data_handler import TorchDataHandler
 from ..types import Callable
@@ -226,6 +227,7 @@ class TorchFeatureExtractor(FeatureExtractor):
         dataset: Union[DataLoader, ItemType],
         postproc_fns: Optional[List[Callable]] = None,
         detach: bool = True,
+        verbose: bool = False,
         **kwargs,
     ) -> Tuple[List[torch.Tensor], dict]:
         """Get the projection of the dataset in the feature space of self.model
@@ -236,6 +238,7 @@ class TorchFeatureExtractor(FeatureExtractor):
                 each feature immediately after forward. Default to None.
             detach (bool): if True, return features detached from the computational
                 graph. Defaults to True.
+            verbose (bool): if True, display a progress bar. Defaults to False.
             kwargs (dict): additional arguments not considered for prediction
 
         Returns:
@@ -257,7 +260,7 @@ class TorchFeatureExtractor(FeatureExtractor):
             logits = None
             batch = next(iter(dataset))
             contains_labels = isinstance(batch, (list, tuple)) and len(batch) > 1
-            for elem in dataset:
+            for elem in tqdm(dataset, desc="Predicting", disable=not verbose):
                 tensor = TorchDataHandler.get_input_from_dataset_item(elem)
                 features_batch, logits_batch = self.predict_tensor(
                     tensor, postproc_fns, detach=detach

--- a/oodeel/methods/dknn.py
+++ b/oodeel/methods/dknn.py
@@ -42,7 +42,7 @@ class DKNN(OODBaseDetector):
 
     def __init__(
         self,
-        nearest: int = 1,
+        nearest: int = 50,
     ):
         super().__init__()
 


### PR DESCRIPTION
A few fixes, spotted when doing the imagenet benchmark of oodeel:

- **Torch dataloader**: 
    Define `num_workers=8` instead of default `num_workers=0` value for the dataloaders in the `prepare` method of the OODDataset ⇒ waaaaaay faster

- **Mahalanobis**:
    - **Fix covariance computation** (spotted by Joseba): It was computed as the mean of the class conditional covariances, now the covariance is evaluated over the whole dataset to match the paper.
    **Old covariance:** $\frac{1}{K}\sum_{1\leq c\leq K}\frac{1}{N_c}\sum_{i:y_i=c}(f(x_i)-\mu_c)(f(x_i)-\mu_c)^T$
    **New covariance:** $\frac{1}{N}\sum_{1\leq c\leq K}\sum_{i:y_i=c}(f(x_i)-\mu_c)(f(x_i)-\mu_c)^T$
   
    - **Less VRAM usage** to compute mean covariance (no need to save all the class covariances, we can do an accumulated mean!)

- **Gram:**
    The default power orders were [1, 2, …, 10], but for a power ≥ 7, some infinite values appear in the powered gram matrices. **So, like OpenOOD, a better default choice would be [1, 2, 3, 4, 5]**.

- **DKNN:**
    Change default value from K=1 to **K=50**