### PR TITLE
Fix Mahalanobis and RMDS methods

### DIFF
--- a/oodeel/methods/mahalanobis.py
+++ b/oodeel/methods/mahalanobis.py
@@ -74,9 +74,9 @@ class Mahalanobis(OODBaseDetector):
                 / _zero_f_cls.shape[0]
             )
             if mean_cov is None:
-                mean_cov = (len(_features_cls) / len(features)) * cov_cls
+                mean_cov = (len(_features_cls) / len(features[0])) * cov_cls
             else:
-                mean_cov += (len(_features_cls) / len(features)) * cov_cls
+                mean_cov += (len(_features_cls) / len(features[0])) * cov_cls
 
         # pseudo-inverse of the mean covariance matrix
         self._pinv_cov = self.op.pinv(mean_cov)

--- a/oodeel/methods/rmds.py
+++ b/oodeel/methods/rmds.py
@@ -96,7 +96,7 @@ class RMDS(Mahalanobis):
 
         # take the highest score for each sample
         gaussian_score_corrected = self.op.max(
-            gaussian_score_bg - gaussian_score_p, dim=1
+            gaussian_score_p - gaussian_score_bg, dim=1
         )
         return -self.op.convert_to_numpy(gaussian_score_corrected)
 


### PR DESCRIPTION
Two bugs are fixed:
- Mahalanobis: the mean covariance for all classes is now correctly computed based on the total number of inputs `len(features[0])` and not `len(features)` which is a list of 1 element.
- RMDS: the formula for the score is $MD_k - MD_0$, and not $MD_0 - MD_k$.