### PR TITLE
feat: added mike for doc versioning

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -83,6 +83,15 @@ plugins:
       ignore: ["ignored_notebooks/*"]
       ignore_h1_titles: True
       include_source: True
+  - mike:
+      # These fields are all optional; the defaults are as below...
+      alias_type: symlink
+      redirect_template: null
+      deploy_prefix: ''
+      canonical_version: null
+      version_selector: true
+      css_dir: css
+      javascript_dir: js
 
 markdown_extensions:
   - footnotes
@@ -113,3 +122,7 @@ extra_javascript:
 
 repo_name: "deel-ai/oodeel"
 repo_url: "https://github.com/deel-ai/oodeel"
+
+extra:
+  version:
+    provider: mike

--- a/setup.cfg
+++ b/setup.cfg
@@ -133,12 +133,12 @@ deps =
     pandas
     seaborn
     plotly == 5.15.0
-    torch112: torch == 1.12.0
-    torch112: torchvision == 0.13.0
+    torch112: torch == 1.12.0+cpu
+    torch112: torchvision == 0.13.0+cpu
     tf211: tensorflow ~= 2.11.0
     tf211: tensorflow_datasets
     tf211: tensorflow_probability ~= 0.19.0
-install_command = uv pip install {opts} {packages}
+install_command = uv pip install --extra-index-url https://download.pytorch.org/whl/cpu {opts} {packages}
 commands =
     tf211: uv pip install --force-reinstall numpy==1.26.0
     coverage run --source oodeel -m pytest

--- a/setup.py
+++ b/setup.py
@@ -70,6 +70,7 @@ dev_requirements = [
     "mkdocs-material",
     "mkdocstrings",
     "mknotebooks",
+    "mike",
     "bump2version",
     "docsig",
     "no_implicit_optional",


### PR DESCRIPTION
This pull request includes changes to the `mkdocs.yml` configuration file and the `setup.py` file to integrate the `mike` plugin for versioning documentation.

Integration of `mike` plugin:

* [`mkdocs.yml`](diffhunk://#diff-98d0f806abc9af24e6a7c545d3d77e8f9ad57643e27211d7a7b896113e420ed2R86-R94): Added configuration for the `mike` plugin, including options such as `alias_type`, `redirect_template`, `deploy_prefix`, `canonical_version`, `version_selector`, `css_dir`, and `javascript_dir`.
* [`mkdocs.yml`](diffhunk://#diff-98d0f806abc9af24e6a7c545d3d77e8f9ad57643e27211d7a7b896113e420ed2R125-R128): Added an `extra` section to specify `mike` as the version provider.
* [`setup.py`](diffhunk://#diff-60f61ab7a8d1910d86d9fda2261620314edcae5894d5aaa236b821c7256badd7R73): Added `mike` to the list of required packages.