### PR TITLE
Feat: VRAM and Speed optimization

### DIFF
--- a/oodeel/eval/plots/features.py
+++ b/oodeel/eval/plots/features.py
@@ -167,8 +167,8 @@ def _plot_features(
 
     # === extract id features ===
     # features
-    in_features, _ = feature_extractor.predict(in_dataset)
-    in_features = op.convert_to_numpy(op.flatten(in_features[0]))[:max_samples]
+    in_features, _ = feature_extractor.predict(in_dataset, numpy_concat=True)
+    in_features = in_features[0].reshape(in_features[0].shape[0], -1)[:max_samples]
 
     # labels
     in_labels = []
@@ -180,8 +180,10 @@ def _plot_features(
     # === extract ood features ===
     if out_dataset is not None:
         # features
-        out_features, _ = feature_extractor.predict(out_dataset)
-        out_features = op.convert_to_numpy(op.flatten(out_features[0]))[:max_samples]
+        out_features, _ = feature_extractor.predict(out_dataset, numpy_concat=True)
+        out_features = out_features[0].reshape(out_features[0].shape[0], -1)[
+            :max_samples
+        ]
 
         # labels
         out_labels_str = np.array(["unknown"] * len(out_features))

--- a/oodeel/eval/plots/features.py
+++ b/oodeel/eval/plots/features.py
@@ -25,6 +25,7 @@ import numpy as np
 import pandas as pd
 import seaborn as sns
 from matplotlib.lines import Line2D
+import sklearn
 from sklearn.decomposition import PCA
 from sklearn.manifold import TSNE
 
@@ -43,6 +44,11 @@ PROJ_DICT = {
     },
     "PCA": {"name": "PCA", "class": PCA, "default_kwargs": dict()},
 }
+
+# check sklearn version: if > 1.5, use max_iter instead of n_iter
+if sklearn.__version__ >= "1.5":
+    n_iter = PROJ_DICT["TSNE"]["default_kwargs"].pop("n_iter")
+    PROJ_DICT["TSNE"]["default_kwargs"]["max_iter"] = n_iter
 
 
 def plot_2D_features(

--- a/oodeel/extractor/keras_feature_extractor.py
+++ b/oodeel/extractor/keras_feature_extractor.py
@@ -340,16 +340,16 @@ class KerasFeatureExtractor(FeatureExtractor):
                     lbl = TFDataHandler.get_label_from_dataset_item(elem)
                     labels_list.append(lbl)
 
-            # Single concatenation
+            # Concatenate
+            labels = tf.concat(labels_list, axis=0) if labels_list is not None else None
+
             if numpy_concat:
                 features = [np.concatenate(lst, axis=0) for lst in features_per_layer]
                 logits = np.concatenate(logits_list, axis=0) if logits_list else None
+                labels = labels.numpy() if labels is not None else None
             else:
                 features = [tf.concat(lst, axis=0) for lst in features_per_layer]
                 logits = tf.concat(logits_list, axis=0) if logits_list else None
-
-            # Concatenate labels if they are available
-            labels = tf.concat(labels_list, axis=0) if labels_list is not None else None
 
         info = {"labels": labels, "logits": logits}
         return features, info

--- a/oodeel/extractor/torch_feature_extractor.py
+++ b/oodeel/extractor/torch_feature_extractor.py
@@ -393,17 +393,17 @@ class TorchFeatureExtractor(FeatureExtractor):
                     lbl = TorchDataHandler.get_label_from_dataset_item(elem)
                     labels_list.append(lbl)
 
-            # Concatenate once
+            # Concatenate
+            labels = torch.cat(labels_list, dim=0) if labels_list is not None else None
+
             if numpy_concat:
                 features = [np.concatenate(lst, axis=0) for lst in features_per_layer]
                 logits = np.concatenate(logits_list, axis=0) if logits_list else None
+                labels = labels.cpu().numpy() if labels is not None else None
 
             else:
                 features = [torch.cat(lst, dim=0) for lst in features_per_layer]
                 logits = torch.cat(logits_list, dim=0) if logits_list else None
-
-            # Concatenate labels if available
-            labels = torch.cat(labels_list, dim=0) if labels_list is not None else None
 
         # Package extra info
         info = {"labels": labels, "logits": logits}

--- a/oodeel/methods/base.py
+++ b/oodeel/methods/base.py
@@ -354,11 +354,12 @@ class OODBaseDetector(ABC):
             model, head_layer_id=head_layer_id, return_penultimate=True
         )
         unclipped_features, _ = penult_feat_extractor.predict(
-            fit_dataset, verbose=verbose, postproc_fns=self.postproc_fns
+            fit_dataset,
+            verbose=verbose,
+            postproc_fns=self.postproc_fns,
+            numpy_concat=True,
         )
-        self.react_threshold = self.op.quantile(
-            unclipped_features[0], self.react_quantile
-        )
+        self.react_threshold = np.quantile(unclipped_features[0], self.react_quantile)
 
     def __call__(self, inputs: Union[ItemType, DatasetType]) -> np.ndarray:
         """

--- a/oodeel/methods/mahalanobis.py
+++ b/oodeel/methods/mahalanobis.py
@@ -170,12 +170,12 @@ class Mahalanobis(OODBaseDetector):
     # ------------------------------------------------------------------
 
     def _fit_layer(
-        self, layer_features: TensorType, labels: TensorType, subset_size: int = 5000
+        self, layer_features: np.ndarray, labels: TensorType, subset_size: int = 5000
     ) -> Tuple[Tuple[Dict[int, TensorType], np.ndarray], Optional[np.ndarray]]:
         """Fit statistics for a single layer and, if required, return scores.
 
         Args:
-            layer_features (TensorType): In-distribution features for the layer.
+            layer_features (np.ndarray): In-distribution features for the layer.
             labels (TensorType): Class labels.
             subset_size (int, optional): Number of samples used to compute initial
                 scores for the aggregator. Defaults to 5000.
@@ -186,6 +186,9 @@ class Mahalanobis(OODBaseDetector):
                 * Optional numpy array of OOD scores for the first subset_size
                   samples (None if no aggregator).
         """
+        if isinstance(layer_features, np.ndarray):
+            layer_features = self.op.from_numpy(layer_features)
+
         mus, pinv_cov = self._compute_layer_stats(layer_features, labels)
 
         scores: Optional[np.ndarray] = None
@@ -245,7 +248,7 @@ class Mahalanobis(OODBaseDetector):
             self.postproc_fns = [self.feature_extractor._default_postproc_fn] * n_layers
 
         features, infos = self.feature_extractor.predict(
-            fit_dataset, postproc_fns=self.postproc_fns, detach=True
+            fit_dataset, postproc_fns=self.postproc_fns, detach=True, numpy_concat=True
         )
         labels = infos["labels"]
 

--- a/oodeel/methods/mahalanobis.py
+++ b/oodeel/methods/mahalanobis.py
@@ -66,7 +66,7 @@ class Mahalanobis(OODBaseDetector):
     # ------------------------------------------------------------------
 
     def _compute_layer_stats(
-        self, layer_features: TensorType, labels: TensorType
+        self, layer_features: TensorType, labels: np.ndarray
     ) -> Tuple[Dict[int, TensorType], np.ndarray]:
         """
         Compute class-conditional statistics for a given feature layer.
@@ -79,21 +79,21 @@ class Mahalanobis(OODBaseDetector):
         Args:
             layer_features (TensorType): Feature tensor for a specific layer extracted
                 from in-distribution data.
-            labels (TensorType): Corresponding labels for the in-distribution data.
+            labels (np.ndarray): Corresponding labels for the in-distribution data.
 
         Returns:
-            Tuple[Dict, np.ndarray]:
+            Tuple[Dict, TensorType]:
                 - A dictionary mapping each class label to its mean feature vector.
                 - The pseudo-inverse of the weighted average covariance matrix.
         """
-        labels_np = self.op.convert_to_numpy(labels)
-        classes = np.sort(np.unique(labels_np))
+        classes = np.sort(np.unique(labels))
+        labels = self.op.from_numpy(labels)  # convert to tensor
 
         feats = self.op.flatten(layer_features)
         n_total = feats.shape[0]
 
         mus: Dict[int, TensorType] = {}
-        mean_cov: Optional[np.ndarray] = None
+        mean_cov: TensorType = None
 
         for cls in classes:
             idx = self.op.equal(labels, cls)
@@ -114,14 +114,14 @@ class Mahalanobis(OODBaseDetector):
         return mus, pinv_cov
 
     def _gaussian_log_probs(
-        self, out_features: TensorType, mus: Dict[int, TensorType], pinv_cov: np.ndarray
+        self, out_features: TensorType, mus: Dict[int, TensorType], pinv_cov: TensorType
     ) -> TensorType:
         """Compute unnormalised Gaussian log-probabilities for all classes.
 
         Args:
             out_features (TensorType): Features of shape [B, D].
             mus (Dict[int, TensorType]): Class mean vectors.
-            pinv_cov (np.ndarray): Pseudo-inverse covariance matrix.
+            pinv_cov (TensorType): Pseudo-inverse covariance matrix.
 
         Returns:
             TensorType: Log-probabilities with shape [B, n_classes].
@@ -170,13 +170,13 @@ class Mahalanobis(OODBaseDetector):
     # ------------------------------------------------------------------
 
     def _fit_layer(
-        self, layer_features: np.ndarray, labels: TensorType, subset_size: int = 5000
+        self, layer_features: np.ndarray, labels: np.ndarray, subset_size: int = 5000
     ) -> Tuple[Tuple[Dict[int, TensorType], np.ndarray], Optional[np.ndarray]]:
         """Fit statistics for a single layer and, if required, return scores.
 
         Args:
             layer_features (np.ndarray): In-distribution features for the layer.
-            labels (TensorType): Class labels.
+            labels (np.ndarray): Class labels.
             subset_size (int, optional): Number of samples used to compute initial
                 scores for the aggregator. Defaults to 5000.
 
@@ -187,7 +187,7 @@ class Mahalanobis(OODBaseDetector):
                   samples (None if no aggregator).
         """
         if isinstance(layer_features, np.ndarray):
-            layer_features = self.op.from_numpy(layer_features)
+            layer_features = self.op.from_numpy(layer_features)  # convert to tensor
 
         mus, pinv_cov = self._compute_layer_stats(layer_features, labels)
 
@@ -201,7 +201,7 @@ class Mahalanobis(OODBaseDetector):
         return (mus, pinv_cov), scores
 
     def _score_layer(
-        self, out_features: TensorType, mus: Dict[int, TensorType], pinv_cov: np.ndarray
+        self, out_features: TensorType, mus: Dict[int, TensorType], pinv_cov: TensorType
     ) -> np.ndarray:
         """
         Compute Mahalanobis distance-based confidence scores for a single feature layer.
@@ -213,7 +213,7 @@ class Mahalanobis(OODBaseDetector):
         Args:
             out_features (TensorType): Feature tensor for test samples.
             mus (Dict): Dictionary mapping each class label to its mean feature vector.
-            pinv_cov (np.ndarray): Pseudo-inverse of the covariance matrix.
+            pinv_cov (TensorType): Pseudo-inverse of the covariance matrix.
 
         Returns:
             TensorType: Confidence scores for each sample for every class,

--- a/oodeel/methods/rmds.py
+++ b/oodeel/methods/rmds.py
@@ -167,7 +167,7 @@ class RMDS(Mahalanobis):
     def _fit_layer(
         self,
         layer_features: np.ndarray,
-        labels: TensorType,
+        labels: np.ndarray,
         subset_size: int = 5000,
     ) -> Tuple[
         Tuple[Dict[int, TensorType], TensorType, TensorType, TensorType],
@@ -177,7 +177,7 @@ class RMDS(Mahalanobis):
 
         Args:
             layer_features (np.ndarray): In-distribution features for the layer.
-            labels (TensorType): Class labels.
+            labels (np.ndarray): Class labels.
             subset_size (int, optional): Number of samples used to compute initial
                 scores for the aggregator. Defaults to 5000.
 

--- a/oodeel/methods/rmds.py
+++ b/oodeel/methods/rmds.py
@@ -166,7 +166,7 @@ class RMDS(Mahalanobis):
 
     def _fit_layer(
         self,
-        layer_features: TensorType,
+        layer_features: np.ndarray,
         labels: TensorType,
         subset_size: int = 5000,
     ) -> Tuple[
@@ -174,6 +174,12 @@ class RMDS(Mahalanobis):
         Optional[np.ndarray],
     ]:
         """Fit *one layer* and optionally return validation-subset scores.
+
+        Args:
+            layer_features (np.ndarray): In-distribution features for the layer.
+            labels (TensorType): Class labels.
+            subset_size (int, optional): Number of samples used to compute initial
+                scores for the aggregator. Defaults to 5000.
 
         Returns
             layer_stats : (mus, pinv_cov, mu_bg, pinv_cov_bg)
@@ -184,6 +190,9 @@ class RMDS(Mahalanobis):
             val_scores : np.ndarray | None
                 Per-sample RMDS scores for an aggregator, or `None`.
         """
+        if isinstance(layer_features, np.ndarray):
+            layer_features = self.op.from_numpy(layer_features)
+
         mus, pinv_cov = super()._compute_layer_stats(layer_features, labels)
         mu_bg, pinv_cov_bg = self._background_stats(layer_features)
 
@@ -257,7 +266,7 @@ class RMDS(Mahalanobis):
 
         # Extract features and labels
         features, infos = self.feature_extractor.predict(
-            fit_dataset, postproc_fns=self.postproc_fns, detach=True
+            fit_dataset, postproc_fns=self.postproc_fns, detach=True, numpy_concat=True
         )
         labels = infos["labels"]
 

--- a/oodeel/methods/she.py
+++ b/oodeel/methods/she.py
@@ -209,7 +209,7 @@ class SHE(OODBaseDetector):
         if self.aggregator is None and len(features) > 1:
             self.aggregator = StdNormalizedAggregator()
 
-        labels_np = self.op.convert_to_numpy(infos["labels"])
+        labels_np = infos["labels"]
         preds_np = np.argmax(infos["logits"], axis=1)
         self._classes = np.sort(np.unique(labels_np))
 


### PR DESCRIPTION
**Features**

- **`TorchFeatureExtractor`**: Wraps the forward pass in `torch.no_grad()` when `detach=True` to prevent gradient tracking.
- **`TorchFeatureExtractor` & `KerasFeatureExtractor`**: Introduce `numpy_concat` flag in `predict`, accumulating outputs as NumPy arrays rather than GPU tensors => significantly reduces VRAM usage for large datasets.
- **`TorchFeatureExtractor` & `KerasFeatureExtractor`**: Move all concatenations out of the batch loop, reducing concatenation complexity from O(N²) to O(N) for much faster execution.
- Extend feature-based OOD detection methods and React threshold computation to support `numpy_concat`.

**Note:** The Gram detector works with very large stats tensors. Running quantile and deviation on the CPU (NumPy) is too slow, but moving whole tensors to the GPU can cause out-of-memory errors. To balance speed and memory use, we now send only the stats for one layer and one class at a time to the GPU for quantile and deviation calculations.

**TODO**

- [ ] In feature-based OOD detection methods, maybe it could be even more optimized: At some points, we still convert large arrays to GPU tensors with `self.op.from_numpy` => could this be avoided to reduce VRAM peaks? 