### PR TITLE
fix: tsne n_iter deprecated -> max_iter

### DIFF
--- a/oodeel/eval/plots/features.py
+++ b/oodeel/eval/plots/features.py
@@ -25,6 +25,7 @@ import numpy as np
 import pandas as pd
 import seaborn as sns
 from matplotlib.lines import Line2D
+import sklearn
 from sklearn.decomposition import PCA
 from sklearn.manifold import TSNE
 
@@ -43,6 +44,11 @@ PROJ_DICT = {
     },
     "PCA": {"name": "PCA", "class": PCA, "default_kwargs": dict()},
 }
+
+# check sklearn version: if > 1.5, use max_iter instead of n_iter
+if sklearn.__version__ >= "1.5":
+    n_iter = PROJ_DICT["TSNE"]["default_kwargs"].pop("n_iter")
+    PROJ_DICT["TSNE"]["default_kwargs"]["max_iter"] = n_iter
 
 
 def plot_2D_features(


### PR DESCRIPTION
Current tests fail because of an argument of TSNE that went deprecated with sklearn > 1.5
This short PR fixes this problem.