### PR TITLE
fix: interpolation for a@xb metrics

### DIFF
--- a/oodeel/eval/metrics.py
+++ b/oodeel/eval/metrics.py
@@ -24,6 +24,7 @@ import re
 
 import numpy as np
 import sklearn
+from scipy.interpolate import interp1d
 
 from ..types import Optional
 from ..types import Tuple
@@ -111,13 +112,10 @@ def bench_metrics(
                 ).groups()
                 thr = int(thr)
                 count_1, count_2 = locals()[count_1_str], locals()[count_2_str]
-                for i, c2 in enumerate(count_2):
-                    if (count_2_str in ["fpr", "tpr"] and c2 < thr / 100) or (
-                        count_2_str in ["tnr", "fnr"] and c2 > thr / 100
-                    ):
-                        ind = i
-                        break
-                metrics_dict[metric] = count_1[ind]
+                interp = interp1d(
+                    count_2, count_1, bounds_error=False, fill_value="extrapolate"
+                )
+                metrics_dict[metric] = interp(thr / 100)
 
         elif metric.__name__ in sklearn.metrics.__all__:
             if metric.__name__[:3] == "roc":

--- a/tests/tests_tensorflow/eval/test_tf_metrics.py
+++ b/tests/tests_tensorflow/eval/test_tf_metrics.py
@@ -24,7 +24,8 @@ import numpy as np
 import pytest
 from pytest import approx
 from sklearn.linear_model import LinearRegression
-from sklearn.metrics import accuracy_score, roc_auc_score
+from sklearn.metrics import accuracy_score
+from sklearn.metrics import roc_auc_score
 
 from oodeel.eval.metrics import bench_metrics
 from oodeel.eval.metrics import ftpn
@@ -88,14 +89,14 @@ def test_bench_metrics(in_value, out_value):
         threshold=0.5,
         step=1,
     )
-    # expected results (hand calculated)
+    # expected results (hand calculated, interpolated values for a@xb metrics)
     assert metrics_dict["auroc"] == approx(1 - (0.4 * 0.8) / 2)
     assert metrics_dict["roc_auc_score"] == approx(1 - (0.4 * 0.8) / 2)
     assert metrics_dict["accuracy_score"] == approx(8 / 10)
     assert metrics_dict["detect_acc"] == approx(8 / 10)
-    assert metrics_dict["tpr50fpr"] == 0.6
-    assert metrics_dict["fpr15tnr"] == 0.8
-    assert metrics_dict["tnr90fpr"] == 0.2
+    assert metrics_dict["tpr50fpr"] == approx(0.625)
+    assert metrics_dict["fpr15tnr"] == approx(0.85)
+    assert metrics_dict["tnr90fpr"] == approx(0.1)
 
     # Assert scores as (scores_in, scores_out) return the same results
     scores_in = scores[labels == in_value]

--- a/tests/tests_torch/eval/test_torch_metrics.py
+++ b/tests/tests_torch/eval/test_torch_metrics.py
@@ -24,7 +24,8 @@ import numpy as np
 import pytest
 from pytest import approx
 from sklearn.linear_model import LinearRegression
-from sklearn.metrics import accuracy_score, roc_auc_score
+from sklearn.metrics import accuracy_score
+from sklearn.metrics import roc_auc_score
 
 from oodeel.eval.metrics import bench_metrics
 from oodeel.eval.metrics import ftpn
@@ -88,14 +89,14 @@ def test_bench_metrics(in_value, out_value):
         threshold=0.5,
         step=1,
     )
-    # expected results (hand calculated)
+    # expected results (hand calculated, interpolated values for a@xb metrics)
     assert metrics_dict["auroc"] == approx(1 - (0.4 * 0.8) / 2)
     assert metrics_dict["roc_auc_score"] == approx(1 - (0.4 * 0.8) / 2)
     assert metrics_dict["accuracy_score"] == approx(8 / 10)
     assert metrics_dict["detect_acc"] == approx(8 / 10)
-    assert metrics_dict["tpr50fpr"] == 0.6
-    assert metrics_dict["fpr15tnr"] == 0.8
-    assert metrics_dict["tnr90fpr"] == 0.2
+    assert metrics_dict["tpr50fpr"] == approx(0.625)
+    assert metrics_dict["fpr15tnr"] == approx(0.85)
+    assert metrics_dict["tnr90fpr"] == approx(0.1)
 
     # Assert scores as (scores_in, scores_out) return the same results
     scores_in = scores[labels == in_value]


### PR DESCRIPTION
### Problem
The `<aaa><XX><bbb>` metrics (e.g., `fpr95tpr`) used discrete lookup, returning the value at the nearest sampled threshold rather than the exact requested threshold.

### Solution
Replace discrete index-based lookup with `scipy.interpolate.interp1d` for accurate continuous estimation at the exact threshold value.

### Changes
- metrics.py: Use interpolation instead of loop-based lookup
- Updated test expected values to match interpolated results

**Note**: I rebased on #121 to address the Black formatting issue.