### PR TITLE
docs: add external reference to `scio`

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -224,6 +224,7 @@ Feel free to propose your ideas or come and contribute with us on the oodeel too
 Other great tools in the field of OOD:
 
 - [OpenOOD](https://github.com/Jingkang50/OpenOOD): Benchmarking Generalized Out-of-Distribution Detection
+- [`scio`](https://github.com/ThalesGroup/scio): Confidence scores for Neural Networks, made easy!
 - [Pytorch-OOD](https://github.com/kkirchheim/pytorch-ood): Out-of-Distribution (OOD) Detection with Deep Neural Networks based on PyTorch.
 - [ADBench](https://github.com/Minqi824/ADBench): Official Implement of "ADBench: Anomaly Detection Benchmark".
 - [PyOD](https://github.com/yzhao062/pyod): A Comprehensive and Scalable Python Library for Outlier Detection (Anomaly Detection)


### PR DESCRIPTION
This PR proposes the addition of [`scio`](https://github.com/ThalesGroup/scio) to the "See Also" section of the docs home page (image), in *second* place.
<img width="1105" height="294" alt="image" src="https://github.com/user-attachments/assets/4a89cd2f-bde2-4ec8-bc6f-5c40f5a212ca" />


I warmly invite you to go and checkout our project, which is close to your in terms of objective. It is however built quite differently, and only supports `PyTorch` models. I rigorously follows up-to-date programming standards, and is extensively documented/tested.

I think it would make sense to have it listed as first in terms of ressemblance, but `OpenOOD` is such an academic landmark that I decided to make `scio` the second in the list. I do think it should be placed before [Pytorch-OOD](https://github.com/kkirchheim/pytorch-ood) since the latter had no release since 2023, while we're actively developed and maintained, also compatible with Python 3.14.

Looking forward to hearing from you!

All the best.
Élie.