### PR TITLE
Deferred imports for datasets libraries (torchvision, tensorflow-datasets, and HF datasets)

### DIFF
--- a/oodeel/datasets/tf_data_handler.py
+++ b/oodeel/datasets/tf_data_handler.py
@@ -23,7 +23,6 @@
 from typing import get_args
 
 import tensorflow as tf
-from datasets import load_dataset as hf_load_dataset
 
 from ..types import Callable
 from ..types import ItemType
@@ -239,6 +238,14 @@ class TFDataHandler(DataHandler):
         Returns:
             tf.data.Dataset: dataset
         """
+        try:
+            from datasets import load_dataset as hf_load_dataset
+        except ImportError:
+            raise ImportError(
+                "datasets is not installed. Please install it to use "
+                'hub="huggingface" in load_dataset.'
+            )
+
         dataset = hf_load_dataset(dataset_id, **load_kwargs)
         dataset = dataset.to_tf_dataset()
         return dataset

--- a/oodeel/datasets/tf_data_handler.py
+++ b/oodeel/datasets/tf_data_handler.py
@@ -23,7 +23,6 @@
 from typing import get_args
 
 import tensorflow as tf
-import tensorflow_datasets as tfds
 from datasets import load_dataset as hf_load_dataset
 
 from ..types import Callable
@@ -259,6 +258,14 @@ class TFDataHandler(DataHandler):
         Returns:
             tf.data.Dataset
         """
+        try:
+            import tensorflow_datasets as tfds
+        except ImportError:
+            raise ImportError(
+                "tensorflow_datasets is not installed. Please install it to use "
+                'hub="tensorflow-datasets" in load_dataset.'
+            )
+
         assert (
             dataset_id in tfds.list_builders()
         ), "Dataset not available on tensorflow datasets catalog"

--- a/oodeel/datasets/torch_data_handler.py
+++ b/oodeel/datasets/torch_data_handler.py
@@ -26,7 +26,6 @@ from typing import get_args
 import numpy as np
 import torch
 import torch.nn.functional as F
-import torchvision
 from datasets import load_dataset as hf_load_dataset
 from torch.utils.data import DataLoader
 from torch.utils.data import Dataset
@@ -421,6 +420,13 @@ class TorchDataHandler(DataHandler):
         Returns:
             DictDataset: dataset
         """
+        try:
+            import torchvision
+        except ImportError:
+            raise ImportError(
+                "torchvision is not installed. Please install it to use "
+                'hub="torchvision" in load_dataset.'
+            )
         assert (
             dataset_id in torchvision.datasets.__all__
         ), "Dataset not available on torchvision datasets catalog"

--- a/oodeel/datasets/torch_data_handler.py
+++ b/oodeel/datasets/torch_data_handler.py
@@ -26,7 +26,6 @@ from typing import get_args
 import numpy as np
 import torch
 import torch.nn.functional as F
-from datasets import load_dataset as hf_load_dataset
 from torch.utils.data import DataLoader
 from torch.utils.data import Dataset
 from torch.utils.data import Subset
@@ -376,6 +375,14 @@ class TorchDataHandler(DataHandler):
         Returns:
             DictDataset: dataset
         """
+        try:
+            from datasets import load_dataset as hf_load_dataset
+        except ImportError:
+            raise ImportError(
+                "datasets is not installed. Please install it to use "
+                'hub="huggingface" in load_dataset.'
+            )
+
         if "transform" in load_kwargs.keys():
             transform = load_kwargs["transform"]
             load_kwargs.pop("transform")

--- a/oodeel/types/__init__.py
+++ b/oodeel/types/__init__.py
@@ -23,6 +23,7 @@
 """
 Typing module
 """
+
 from typing import Any
 from typing import Callable
 from typing import Dict

--- a/setup.cfg
+++ b/setup.cfg
@@ -51,6 +51,7 @@ deps =
     pandas
     seaborn
     requests
+    datasets
     plotly == 5.15.0
     tf211: protobuf>=3.9.2,<3.20
     tf213: protobuf>=3.20.3,<4.21.0
@@ -103,15 +104,19 @@ deps =
     torch200: torch == 2.0.0+cpu
     torch200: torchvision == 0.15.0+cpu
     torch200: transformers == 4.49.0
+    torch200: datasets==2.19.1
     torch22: torch == 2.2.0+cpu
     torch22: torchvision == 0.17.0+cpu
     torch22: transformers == 4.49.0
+    torch24: datasets==2.19.1
     torch24: torch == 2.4.0+cpu
     torch24: torchvision == 0.19.0+cpu
     torch24: transformers == 4.49.0
+    torch24: datasets==2.19.1
     torch26: torch == 2.6.0+cpu
     torch26: torchvision == 0.21.0+cpu
     torch26: transformers == 4.49.0
+    torch26: datasets
 install_command = uv pip install --extra-index-url https://download.pytorch.org/whl/cpu {opts} {packages}
 setenv =
     DL_LIB = torch
@@ -154,9 +159,11 @@ deps =
     torch22: torch == 2.2.0+cpu
     torch22: torchvision == 0.17.0+cpu
     torch22: transformers == 4.49.0
+    torch22: datasets==2.19.1
     tf215: tensorflow ~= 2.15.0
     tf215: tensorflow_datasets
     tf215: tensorflow_probability ~= 0.23.0
+    tf215: datasets
 install_command = uv pip install --extra-index-url https://download.pytorch.org/whl/cpu {opts} {packages}
 setenv =
     DL_LIB = both

--- a/setup.py
+++ b/setup.py
@@ -40,16 +40,16 @@ requirements = [
     "seaborn",
     "plotly",
     "tqdm",
-    "datasets",
 ]
 
 tensorflow_requirements = [
     "tensorflow==2.11.0",
     "tensorflow_datasets",
     "tensorflow_probability==0.19.0",
+    "datasets",
 ]
 
-torch_requirements = ["timm", "torch==1.13.1", "torchvision==0.14.1"]
+torch_requirements = ["timm", "torch==1.13.1", "torchvision==0.14.1", "datasets"]
 
 dev_requirements = [
     "mypy",


### PR DESCRIPTION
Torchvision and tensorflow-datasets (tfds) are not dependencies of oodeel. In DataHandlers, the imports for those packages are then deferred in the corresponding functions to avoid `ImportError` if not installed. The error will only be raised if a torchvision or tfds dataset is requested by the user.

For HuggingFace `datasets` library, same thing is done: the import is deferred in the `load_from_huggingface` function. Moreover, to be consistent with torchvision and tfds, the `datasets` dependency is removed from setup.py.

Solves issue #116 